### PR TITLE
Introduce MycoGram and strip Starlight docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MycoSci Website
 
-MycoSci is a community-driven portal cataloging the fungal kingdom. The site is built with [Astro](https://astro.build) and styled using [Bootstrap](https://getbootstrap.com) for a clean, professional look.
+MycoSci is a community-driven portal cataloging the fungal kingdom. The site is built with [Astro](https://astro.build) and styled using [Bootstrap](https://getbootstrap.com) for a clean, professional look. The prior Starlight documentation theme has been removed in favor of a custom Bootstrap interface. Legacy markdown content remains in `src/content/` for future use.
 
 ## Development
 
@@ -21,6 +21,7 @@ Run the following commands from the project root:
 ├── src/
 │   ├── layouts/     # Reusable page layouts
 │   └── pages/       # Site pages
+├── src/content/    # Markdown data (legacy docs)
 ├── astro.config.mjs
 └── package.json
 ```

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,12 @@
+body {
+  font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.navbar-brand {
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+.card-img-top {
+  object-fit: cover;
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,1 @@
-import { defineCollection } from 'astro:content';
-import { docsLoader } from '@astrojs/starlight/loaders';
-import { docsSchema } from '@astrojs/starlight/schema';
-
-export const collections = {
-	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
-};
+export const collections = {};

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -13,6 +13,7 @@ const { title } = Astro.props;
       integrity="sha384-GtvkM3I9AGJDcUJXmh1UnIFVnyGryuVKy7jH9MuNoMNFcQJUO2c+hJ1ytY1/6V2y"
       crossorigin="anonymous"
     />
+    <link rel="stylesheet" href="/styles.css" />
   </head>
   <body class="bg-light d-flex flex-column min-vh-100">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -33,6 +34,9 @@ const { title } = Astro.props;
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">
             <li class="nav-item">
               <a class="nav-link" href="/gallery">Gallery</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/mycogram">MycoGram</a>
             </li>
           </ul>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,6 +22,11 @@ import MainLayout from '../layouts/MainLayout.astro';
         ))}
       </div>
     </section>
+    <section class="mb-5 text-center">
+      <h2 class="mb-3">Join MycoGram</h2>
+      <p>Browse community photos and share your own mushroom finds.</p>
+      <a class="btn btn-primary" href="/mycogram">Open MycoGram</a>
+    </section>
     <section class="mb-5">
       <h2>About</h2>
       <p>

--- a/src/pages/mycogram.astro
+++ b/src/pages/mycogram.astro
@@ -1,0 +1,22 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+
+<MainLayout title="MycoGram">
+  <div class="container my-5">
+    <h1 class="mb-4 text-center">MycoGram</h1>
+    <p class="mb-5 text-center">Share and explore mushroom photos from around the world.</p>
+    <div class="row row-cols-2 row-cols-md-4 g-4">
+      {Array.from({ length: 12 }).map((_, i) => (
+        <div class="col" key={i}>
+          <div class="card h-100 shadow-sm">
+            <img src="https://via.placeholder.com/300" class="card-img-top" alt="Mushroom snapshot" />
+            <div class="card-body">
+              <p class="card-text small text-muted">Amazing mushroom #{i + 1}</p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  </div>
+</MainLayout>


### PR DESCRIPTION
## Summary
- remove Starlight content configuration
- add custom stylesheet and clean navbar
- add MycoGram page and link from homepage
- reference legacy docs in README

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dc7184ac48323956296a4cecce0e1