### PR TITLE
Bootstrap layout for species pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MycoSci Website
 
-MycoSci is a community-driven portal cataloging the fungal kingdom. The site is built with [Astro](https://astro.build) and styled using [Bootstrap](https://getbootstrap.com) for a crisp, NASA-inspired look. The former Starlight documentation theme was removed in favor of our own Bootstrap layout. Legacy markdown content remains in `src/content/` for future reference.
+MycoSci is a community-driven portal cataloging the fungal kingdom. The site is built with [Astro](https://astro.build) and styled using [Bootstrap](https://getbootstrap.com) for a crisp, NASA-inspired look. The former Starlight documentation theme was removed in favor of our own Bootstrap layout. Legacy markdown content remains in `src/content/` for future reference. Our new design will grow into thousands of dynamic species pages as we map over **100k** mushrooms with a trustworthy interface.
 
 ## Development
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,5 +1,7 @@
 body {
   font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  background-color: #0b0d17;
+  color: #ffffff;
 }
 
 .navbar-brand {
@@ -15,4 +17,9 @@ body {
   background: url('/houston.webp') center/cover no-repeat;
   color: #fff;
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
+}
+
+.card {
+  background-color: #1b1f2a;
+  border-color: #2a2f3b;
 }

--- a/src/data/species.json
+++ b/src/data/species.json
@@ -1,0 +1,14 @@
+[
+  {
+    "slug": "amanita-muscaria",
+    "common_name": "Fly Agaric",
+    "scientific_name": "Amanita muscaria",
+    "description": "Iconic red mushroom with white spots, known for its psychoactive properties."
+  },
+  {
+    "slug": "pleurotus-ostreatus",
+    "common_name": "Oyster Mushroom",
+    "scientific_name": "Pleurotus ostreatus",
+    "description": "Edible mushroom widely cultivated and found on decaying wood."
+  }
+]

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -15,7 +15,7 @@ const { title } = Astro.props;
     />
     <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body class="bg-light d-flex flex-column min-vh-100">
+  <body class="bg-dark text-white d-flex flex-column min-vh-100">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">
         <a class="navbar-brand" href="/">MycoSci</a>

--- a/src/pages/mycopedia.astro
+++ b/src/pages/mycopedia.astro
@@ -1,11 +1,25 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import speciesData from '../data/species.json';
 ---
 
 <MainLayout title="MycoPedia">
   <div class="container my-5">
     <h1 class="mb-4 text-center">MycoPedia</h1>
     <p class="lead text-center">Comprehensive knowledge base of mushrooms.</p>
-    <p class="text-center">Species profiles and taxonomy information will live here.</p>
+    <div class="row row-cols-1 row-cols-md-2 g-4">
+      {speciesData.map((sp) => (
+        <div class="col" key={sp.slug}>
+          <div class="card h-100 bg-dark text-white">
+            <div class="card-body">
+              <h5 class="card-title">{sp.common_name}</h5>
+              <p class="card-text fst-italic">{sp.scientific_name}</p>
+              <p class="card-text">{sp.description}</p>
+              <a href={`/species/${sp.slug}`} class="btn btn-primary btn-sm">Read More</a>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
   </div>
 </MainLayout>

--- a/src/pages/species/[slug].astro
+++ b/src/pages/species/[slug].astro
@@ -1,0 +1,16 @@
+---
+import speciesData from '../../data/species.json';
+import MainLayout from '../../layouts/MainLayout.astro';
+const { slug } = Astro.params;
+const entry = speciesData.find(s => s.slug === slug);
+const species = entry ?? { common_name: 'Unknown Species', scientific_name: slug, description: 'Information coming soon.' };
+---
+
+<MainLayout title={species.common_name}>
+  <div class="container my-5">
+    <h1 class="mb-3 text-center">{species.common_name}</h1>
+    <h2 class="h5 text-center fst-italic">{species.scientific_name}</h2>
+    <p class="lead text-center mb-4">{species.description}</p>
+    <p class="text-center text-muted">More data will be added as the catalog grows.</p>
+  </div>
+</MainLayout>

--- a/template.md
+++ b/template.md
@@ -3,7 +3,6 @@ title: "{{common_name}} ({{genus}} {{species}})"
 description: "{{description}}"
 ---
 
-import { Card, CardGrid, Badge, Aside, Steps, Tabs, TabItem, Icon, LinkButton } from '@astrojs/starlight/components';
 
 # *{{genus}} {{species}}*
 

--- a/template_index.md
+++ b/template_index.md
@@ -3,7 +3,6 @@ title: "{{common_names}} ({{genus}} {{species}})"
 description: "{{description}}"
 ---
 
-import { Card, CardGrid, Badge, Aside, Steps, Tabs, TabItem, Icon, LinkButton } from '@astrojs/starlight/components';
 
 # *{{genus}} {{species}}*
 

--- a/template_species.md
+++ b/template_species.md
@@ -3,7 +3,6 @@ title: "{{common_names}} ({{genus}} {{species}})"
 description: "{{description}}"
 ---
 
-import { Card, CardGrid, Badge, Aside, Steps, Tabs, TabItem, Icon, LinkButton } from '@astrojs/starlight/components';
 
 # *{{genus}} {{species}}*
 


### PR DESCRIPTION
## Summary
- switch to a dark bootstrap theme
- remove Starlight imports from templates
- show sample species list and detail pages
- describe goal of 100k dynamic pages in README

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dcae8bdc88323b00334d42dc77058