### PR TITLE
Fix species routes and add hero styling

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -17,6 +17,10 @@ body {
   background: url('/houston.webp') center/cover no-repeat;
   color: #fff;
   text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
+  min-height: 50vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .card {

--- a/src/pages/species/[slug].astro
+++ b/src/pages/species/[slug].astro
@@ -1,16 +1,35 @@
 ---
 import speciesData from '../../data/species.json';
 import MainLayout from '../../layouts/MainLayout.astro';
+
+export async function getStaticPaths() {
+  return speciesData.map((sp) => ({ params: { slug: sp.slug } }));
+}
+
 const { slug } = Astro.params;
-const entry = speciesData.find(s => s.slug === slug);
-const species = entry ?? { common_name: 'Unknown Species', scientific_name: slug, description: 'Information coming soon.' };
+const entry = speciesData.find((s) => s.slug === slug);
+const species =
+  entry ?? {
+    common_name: 'Unknown Species',
+    scientific_name: slug,
+    description: 'Information coming soon.',
+  };
 ---
 
 <MainLayout title={species.common_name}>
   <div class="container my-5">
-    <h1 class="mb-3 text-center">{species.common_name}</h1>
-    <h2 class="h5 text-center fst-italic">{species.scientific_name}</h2>
-    <p class="lead text-center mb-4">{species.description}</p>
-    <p class="text-center text-muted">More data will be added as the catalog grows.</p>
+    <div class="card bg-dark text-white shadow-lg mx-auto" style="max-width: 50rem;">
+      <img
+        src="https://via.placeholder.com/800x400"
+        class="card-img-top"
+        alt={species.common_name}
+      />
+      <div class="card-body text-center">
+        <h1 class="card-title mb-3">{species.common_name}</h1>
+        <h2 class="h5 fst-italic">{species.scientific_name}</h2>
+        <p class="card-text mt-3">{species.description}</p>
+        <p class="text-muted">More data will be added as the catalog grows.</p>
+      </div>
+    </div>
   </div>
 </MainLayout>


### PR DESCRIPTION
## Summary
- generate static paths for species pages
- style hero section and species details with Bootstrap

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dd61283a483238b3a87a87135e981