### PR TITLE
Restore Starlight config for docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,13 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
-
+import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://mycosci.com',
+  integrations: [
+    starlight({
+      title: 'MycoSci',
+      social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/mycosci' }],
+    }),
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "astro": "^5.6.1",
-    "sharp": "^0.32.5"
+    "sharp": "^0.32.5",
+    "@astrojs/starlight": "^0.34.1"
   }
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,1 +1,7 @@
-export const collections = {};
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};


### PR DESCRIPTION
## Summary
- restore Starlight integration
- restore docs collections config
- add `@astrojs/starlight` dependency

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683de7116dc08323b5ffc6f934a2ae2e