### PR TITLE
Remove Starlight integration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,8 +1,16 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
-
+import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://mycosci.com',
+  integrations: [mdx()],
+  vite: {
+    resolve: {
+      alias: {
+        '@astrojs/starlight/components': './src/components/starlight/index.ts',
+      },
+    },
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "astro": "^5.6.1",
-        "sharp": "^0.32.5"
+        "sharp": "^0.32.5",
+        "@astrojs/mdx": "^3.3.0"
       }
     },
     "node_modules/@astrojs/compiler": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "astro": "^5.6.1",
-    "sharp": "^0.32.5"
+    "sharp": "^0.32.5",
+    "@astrojs/mdx": "^3.3.0"
   }
 }

--- a/src/components/starlight/Aside.astro
+++ b/src/components/starlight/Aside.astro
@@ -1,0 +1,8 @@
+---
+const { type, title } = Astro.props;
+const variant = type === 'caution' ? 'warning' : type === 'note' ? 'info' : 'secondary';
+---
+<div class={`alert alert-${variant}`}> 
+  {title && <h5 class="alert-heading">{title}</h5>}
+  <slot />
+</div>

--- a/src/components/starlight/Badge.astro
+++ b/src/components/starlight/Badge.astro
@@ -1,0 +1,4 @@
+---
+const { text, variant } = Astro.props;
+---
+<span class={`badge bg-${variant ?? 'secondary'} me-1`}>{text}</span>

--- a/src/components/starlight/Card.astro
+++ b/src/components/starlight/Card.astro
@@ -1,0 +1,15 @@
+---
+const { title, icon } = Astro.props;
+---
+<div class="col">
+  <div class="card h-100 text-dark">
+    {title && (
+      <div class="card-header">
+        {icon && <span class="me-1">{icon}</span>}{title}
+      </div>
+    )}
+    <div class="card-body">
+      <slot />
+    </div>
+  </div>
+</div>

--- a/src/components/starlight/CardGrid.astro
+++ b/src/components/starlight/CardGrid.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="row row-cols-1 row-cols-md-2 g-3">
+  <slot />
+</div>

--- a/src/components/starlight/Icon.astro
+++ b/src/components/starlight/Icon.astro
@@ -1,0 +1,4 @@
+---
+const { name } = Astro.props;
+---
+<span class={`bi-${name}`}></span>

--- a/src/components/starlight/LinkButton.astro
+++ b/src/components/starlight/LinkButton.astro
@@ -1,0 +1,8 @@
+---
+const { href = '#', variant = 'primary', icon, iconPlacement = 'end' } = Astro.props;
+---
+<a href={href} class={`btn btn-link text-${variant}`}> 
+  {icon && iconPlacement === 'start' && <span class={`bi-${icon} me-1`}></span>}
+  <slot />
+  {icon && iconPlacement === 'end' && <span class={`bi-${icon} ms-1`}></span>}
+</a>

--- a/src/components/starlight/Steps.astro
+++ b/src/components/starlight/Steps.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="my-3">
+  <slot />
+</div>

--- a/src/components/starlight/TabItem.astro
+++ b/src/components/starlight/TabItem.astro
@@ -1,0 +1,7 @@
+---
+const { label } = Astro.props;
+---
+<section class="mb-3">
+  {label && <h4>{label}</h4>}
+  <slot />
+</section>

--- a/src/components/starlight/Tabs.astro
+++ b/src/components/starlight/Tabs.astro
@@ -1,0 +1,5 @@
+---
+---
+<div class="tabs">
+  <slot />
+</div>

--- a/src/components/starlight/index.ts
+++ b/src/components/starlight/index.ts
@@ -1,0 +1,9 @@
+export { default as Badge } from './Badge.astro';
+export { default as Card } from './Card.astro';
+export { default as CardGrid } from './CardGrid.astro';
+export { default as Aside } from './Aside.astro';
+export { default as Steps } from './Steps.astro';
+export { default as Tabs } from './Tabs.astro';
+export { default as TabItem } from './TabItem.astro';
+export { default as Icon } from './Icon.astro';
+export { default as LinkButton } from './LinkButton.astro';


### PR DESCRIPTION
## Summary
- strip Starlight from build and configs
- use `@astrojs/mdx` instead
- create simple replacements for Starlight components

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683de7116dc08323b5ffc6f934a2ae2e