### PR TITLE
Fix missing version for @astrojs/mdx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "astro": "^5.6.1",
         "sharp": "^0.32.5",
-        "@astrojs/mdx": "^3.3.0"
+        "@astrojs/mdx": "^4.2.5"
       }
     },
     "node_modules/@astrojs/compiler": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "dependencies": {
     "astro": "^5.6.1",
     "sharp": "^0.32.5",
-    "@astrojs/mdx": "^3.3.0"
+    "@astrojs/mdx": "^4.2.5"
   }
 }


### PR DESCRIPTION
## Summary
- update `@astrojs/mdx` to a valid version in `package.json`
- update lockfile to match

## Testing
- `npm install` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683deb2d9ce48323828ad9a96f8dde7c