### PR TITLE
Fix docs dynamic routing

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,1 +1,11 @@
-export const collections = {};
+import { defineCollection, z } from 'astro:content';
+
+const docs = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string().optional(),
+    description: z.string().optional(),
+  }),
+});
+
+export const collections = { docs };

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -1,5 +1,18 @@
 ---
 import MainLayout from '../../layouts/MainLayout.astro';
+
+export async function getStaticPaths() {
+  const pages = import.meta.glob('../../content/docs/**/*.{md,mdx}');
+  return Object.keys(pages)
+    .filter((path) => !path.endsWith('/index.mdx'))
+    .map((path) => {
+      const relative = path
+        .replace('../../content/docs/', '')
+        .replace(/\.(md|mdx)$/, '');
+      return { params: { slug: relative.split('/') } };
+    });
+}
+
 const slugArray = Astro.params.slug;
 const pathBase = '../../content/docs/' + slugArray.join('/');
 const mdxPages = import.meta.glob('../../content/docs/**/*.mdx');


### PR DESCRIPTION
## Summary
- implement `getStaticPaths` for docs dynamic route
- define the docs collection in `content.config.ts`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dece624808323a56c3a065cada93b