### PR TITLE
Fix SRI hashes and replace broken placeholders

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -15,7 +15,7 @@ import Footer from '../components/Footer.astro';
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
       rel="stylesheet"
-      integrity="sha384-GtvkM3I9AGJDcUJXmh1UnIFVnyGryuVKy7jH9MuNoMNFcQJUO2c+hJ1ytY1/6V2y"
+      integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
       crossorigin="anonymous"
     />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -31,7 +31,7 @@ import Footer from '../components/Footer.astro';
     <Footer />
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-8eB70SuYQdGSqtEtFPd0PfrxGX3YeliYg+6TSHI+b/xGaxzwoMPmxjSPdZRhqUTr"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
       crossorigin="anonymous"
     ></script>
   </body>

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -10,7 +10,7 @@ import MainLayout from '../layouts/MainLayout.astro';
       {Array.from({ length: 20 }).map(() => (
         <div class="col">
           <div class="card h-100">
-            <img src="https://via.placeholder.com/200" class="card-img-top" alt="Mushroom photo" />
+            <img src="/houston.webp" class="card-img-top" alt="Mushroom photo" />
           </div>
         </div>
       ))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,7 +68,7 @@ const featured = speciesData.slice(0, 4);
         {Array.from({ length: 8 }).map(() => (
           <div class="col">
             <div class="card">
-              <img src="https://via.placeholder.com/150" class="card-img-top" alt="Mushroom photo" />
+              <img src="/houston.webp" class="card-img-top" alt="Mushroom photo" />
             </div>
           </div>
         ))}

--- a/src/pages/mycogram.astro
+++ b/src/pages/mycogram.astro
@@ -10,7 +10,7 @@ import MainLayout from '../layouts/MainLayout.astro';
       {Array.from({ length: 12 }).map((_, i) => (
         <div class="col" key={i}>
           <div class="card h-100 shadow-sm">
-            <img src="https://via.placeholder.com/300" class="card-img-top" alt="Mushroom snapshot" />
+            <img src="/houston.webp" class="card-img-top" alt="Mushroom snapshot" />
             <div class="card-body">
               <p class="card-text small text-muted">Amazing mushroom #{i + 1}</p>
             </div>

--- a/src/pages/species/[slug].astro
+++ b/src/pages/species/[slug].astro
@@ -20,7 +20,7 @@ const species =
   <div class="container my-5">
     <div class="card bg-dark text-white shadow-lg mx-auto" style="max-width: 50rem;">
       <img
-        src="https://via.placeholder.com/800x400"
+        src="/houston.webp"
         class="card-img-top"
         alt={species.common_name}
       />


### PR DESCRIPTION
## Summary
- fix Bootstrap SRI hashes in `MainLayout.astro`
- replace remote placeholder image URLs with a local image

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e0e9237e0832399230da5cca02b53