### PR TITLE
Fix slug array in docs

### DIFF
--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -9,12 +9,13 @@ export async function getStaticPaths() {
       const relative = path
         .replace('../../content/docs/', '')
         .replace(/\.(md|mdx)$/, '');
-      return { params: { slug: relative } };
+      return { params: { slug: relative.split('/') } };
     });
 }
 
 const slugParam = Astro.params.slug;
-const pathBase = '../../content/docs/' + slugParam;
+const slugPath = Array.isArray(slugParam) ? slugParam.join('/') : slugParam;
+const pathBase = '../../content/docs/' + slugPath;
 const mdxPages = import.meta.glob('../../content/docs/**/*.mdx');
 const mdPages = import.meta.glob('../../content/docs/**/*.md');
 let pageImport = mdxPages[pathBase + '.mdx'] || mdPages[pathBase + '.md'];


### PR DESCRIPTION
## Summary
- update docs dynamic route to return slug arrays for catch-all
- normalize slug parameter when loading docs

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e2f57f56c832384e6ca1a27075290