### PR TITLE
Connect taxonomy docs to MycoPedia

### DIFF
--- a/src/pages/mycopedia.astro
+++ b/src/pages/mycopedia.astro
@@ -21,5 +21,12 @@ import speciesData from '../data/species.json';
         </div>
       ))}
     </div>
+    <div class="text-center mt-5">
+      <a
+        href="/mycopedia/taxonomy/taxonomy-intro"
+        class="btn btn-primary btn-lg"
+        >Explore Taxonomy Docs</a
+      >
+    </div>
   </div>
 </MainLayout>

--- a/src/pages/mycopedia/taxonomy/[...slug].astro
+++ b/src/pages/mycopedia/taxonomy/[...slug].astro
@@ -1,0 +1,31 @@
+---
+import MainLayout from '../../../layouts/MainLayout.astro';
+
+export async function getStaticPaths() {
+  const pages = import.meta.glob('../../../content/docs/Taxonomy/**/*.{md,mdx}');
+  return Object.keys(pages)
+    .filter((path) => !path.endsWith('/index.mdx'))
+    .map((path) => {
+      const relative = path
+        .replace('../../../content/docs/Taxonomy/', '')
+        .replace(/\.(md|mdx)$/, '');
+      return { params: { slug: relative.split('/') } };
+    });
+}
+
+const slugParam = Astro.params.slug;
+const slugPath = Array.isArray(slugParam) ? slugParam.join('/') : slugParam;
+const pathBase = '../../../content/docs/Taxonomy/' + slugPath;
+const mdxPages = import.meta.glob('../../../content/docs/Taxonomy/**/*.mdx');
+const mdPages = import.meta.glob('../../../content/docs/Taxonomy/**/*.md');
+let pageImport = mdxPages[pathBase + '.mdx'] || mdPages[pathBase + '.md'];
+let Content;
+if (pageImport) {
+  Content = (await pageImport()).default;
+} else {
+  throw new Error(`Document not found: ${pathBase}`);
+}
+---
+<MainLayout title="Taxonomy">
+  <Content />
+</MainLayout>

--- a/src/pages/mycopedia/taxonomy/index.astro
+++ b/src/pages/mycopedia/taxonomy/index.astro
@@ -1,0 +1,7 @@
+---
+import TaxoDoc from '../../../content/docs/Taxonomy/taxonomy-intro.md';
+import MainLayout from '../../../layouts/MainLayout.astro';
+---
+<MainLayout title="Taxonomy">
+  <TaxoDoc />
+</MainLayout>


### PR DESCRIPTION
## Summary
- expose taxonomy docs under `/mycopedia/taxonomy`
- add button on MycoPedia landing page linking to the docs

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8573f1b88323b30f44787d343f61