### PR TITLE
Add simple blog section

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,6 +16,7 @@
         <h5 class="text-uppercase">Learn</h5>
         <ul class="list-unstyled">
           <li><a href="/docs" class="footer-link">Docs</a></li>
+          <li><a href="/blog" class="footer-link">Blog</a></li>
           <li><a href="/resources" class="footer-link">Resources</a></li>
           <li><a href="/lab" class="footer-link">Lab &amp; Cultivation</a></li>
         </ul>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@
         <li class="nav-item"><a class="nav-link" href="/explore">Explore</a></li>
         <li class="nav-item"><a class="nav-link" href="/gallery">Gallery</a></li>
         <li class="nav-item"><a class="nav-link" href="/mycopedia">MycoPedia</a></li>
+        <li class="nav-item"><a class="nav-link" href="/blog">Blog</a></li>
         <li class="nav-item"><a class="nav-link" href="/lab">Lab &amp; Cultivation</a></li>
         <li class="nav-item"><a class="nav-link" href="/community">Community</a></li>
       </ul>

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -1,0 +1,12 @@
+[
+  {
+    "slug": "jdoe",
+    "name": "Jane Doe",
+    "bio": "Science writer and mycology enthusiast who loves exploring the hidden world of fungi."
+  },
+  {
+    "slug": "asmith",
+    "name": "Alex Smith",
+    "bio": "Cultivator and educator sharing practical techniques for mushroom growers."
+  }
+]

--- a/src/data/posts.json
+++ b/src/data/posts.json
@@ -1,0 +1,26 @@
+[
+  {
+    "slug": "fungal-frontiers",
+    "title": "Fungal Frontiers: New Discoveries",
+    "author": "jdoe",
+    "date": "2023-11-01",
+    "snippet": "Recent research is uncovering amazing fungal secrets.",
+    "content": "<p>The world of mycology is expanding with new species and novel applications discovered each year. From bioremediation to sustainable materials, fungi are proving to be indispensable allies.</p>"
+  },
+  {
+    "slug": "cultivation-basics",
+    "title": "Cultivation Basics for Beginners",
+    "author": "asmith",
+    "date": "2023-10-15",
+    "snippet": "Starting a mushroom grow can be simple with the right approach.",
+    "content": "<p>With just a few supplies and some patience, you can cultivate gourmet mushrooms at home. We'll cover substrate preparation, inoculation, and fruiting conditions.</p>"
+  },
+  {
+    "slug": "edible-vs-poisonous",
+    "title": "Edible vs. Poisonous Lookalikes",
+    "author": "jdoe",
+    "date": "2023-09-30",
+    "snippet": "Learn to tell delicious mushrooms from dangerous imposters.",
+    "content": "<p>Field identification is a vital skill for foragers. We'll compare common edible species with their toxic counterparts and share tips to stay safe.</p>"
+  }
+]

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,29 @@
+---
+import posts from '../../data/posts.json';
+import authors from '../../data/authors.json';
+import MainLayout from '../../layouts/MainLayout.astro';
+
+export async function getStaticPaths() {
+  return posts.map(p => ({ params: { slug: p.slug } }));
+}
+
+const { slug } = Astro.params;
+const post = posts.find(p => p.slug === slug);
+const author = post ? authors.find(a => a.slug === post.author) : null;
+---
+
+{post ? (
+  <MainLayout title={post.title} description={post.snippet}>
+    <article class="mb-5">
+      <h1 class="mb-3">{post.title}</h1>
+      {author && (
+        <p><small>By <a href={`/blog/authors/${author.slug}`}>{author.name}</a> on {post.date}</small></p>
+      )}
+      <div innerHTML={post.content}></div>
+    </article>
+  </MainLayout>
+) : (
+  <MainLayout title="Post not found">
+    <p>Sorry, this article could not be found.</p>
+  </MainLayout>
+)}

--- a/src/pages/blog/authors/[slug].astro
+++ b/src/pages/blog/authors/[slug].astro
@@ -1,0 +1,36 @@
+---
+import posts from '../../../data/posts.json';
+import authors from '../../../data/authors.json';
+import MainLayout from '../../../layouts/MainLayout.astro';
+
+export async function getStaticPaths() {
+  return authors.map(a => ({ params: { slug: a.slug } }));
+}
+
+const { slug } = Astro.params;
+const author = authors.find(a => a.slug === slug);
+const authorPosts = posts.filter(p => p.author === slug);
+---
+
+{author ? (
+  <MainLayout title={author.name} description={`Posts by ${author.name}`}
+  >
+    <h1 class="mb-3">{author.name}</h1>
+    <p class="mb-4">{author.bio}</p>
+    {authorPosts.length > 0 ? (
+      <ul>
+        {authorPosts.map(post => (
+          <li key={post.slug}>
+            <a href={`/blog/${post.slug}`}>{post.title}</a>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p>No posts yet.</p>
+    )}
+  </MainLayout>
+) : (
+  <MainLayout title="Author not found">
+    <p>Sorry, this author does not exist.</p>
+  </MainLayout>
+)}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,30 @@
+---
+import posts from '../../data/posts.json';
+import authors from '../../data/authors.json';
+import MainLayout from '../../layouts/MainLayout.astro';
+
+function getAuthor(slug) {
+  return authors.find(a => a.slug === slug) ?? {name: slug};
+}
+
+const sorted = posts.sort((a,b) => new Date(b.date) - new Date(a.date));
+---
+
+<MainLayout title="Blog" description="News and articles from the MycoSci community">
+  <h1 class="mb-4">Latest Posts</h1>
+  <div class="row row-cols-1 row-cols-md-2 g-4">
+    {sorted.map(post => (
+      <div class="col" key={post.slug}>
+        <div class="card bg-dark text-white h-100">
+          <div class="card-body">
+            <h3 class="card-title">
+              <a href={`/blog/${post.slug}`} class="stretched-link text-white text-decoration-none">{post.title}</a>
+            </h3>
+            <p class="mb-1"><small>By <a href={`/blog/authors/${post.author}`}>{getAuthor(post.author).name}</a> on {post.date}</small></p>
+            <p class="card-text">{post.snippet}</p>
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+</MainLayout>


### PR DESCRIPTION
## Summary
- add blog home, author, and article pages
- store sample blog posts and authors in JSON data
- link the new blog in the header and footer

## Testing
- `npm install` *(fails: `Exit handler never called`)*
- `npm run build` *(fails: `astro: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683e85abf7608323b493cb3825db1213