### PR TITLE
Enhance author pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ The site features a Bootstrap-powered navbar linking to key sections:
 - **Lab & Cultivation** – teks and protocols
 - **Community** – forums and events
 - **Resources** – videos, podcasts, and research links
+- **Blog** – news articles and tutorials
+- **Author Directory** – bios of contributors

--- a/src/data/authors.json
+++ b/src/data/authors.json
@@ -2,11 +2,13 @@
   {
     "slug": "jdoe",
     "name": "Jane Doe",
-    "bio": "Science writer and mycology enthusiast who loves exploring the hidden world of fungi."
+    "bio": "Science writer and mycology enthusiast who loves exploring the hidden world of fungi.",
+    "avatar": "https://via.placeholder.com/150"
   },
   {
     "slug": "asmith",
     "name": "Alex Smith",
-    "bio": "Cultivator and educator sharing practical techniques for mushroom growers."
+    "bio": "Cultivator and educator sharing practical techniques for mushroom growers.",
+    "avatar": "https://via.placeholder.com/150"
   }
 ]

--- a/src/pages/blog/authors/[slug].astro
+++ b/src/pages/blog/authors/[slug].astro
@@ -15,19 +15,42 @@ const authorPosts = posts.filter(p => p.author === slug);
 {author ? (
   <MainLayout title={author.name} description={`Posts by ${author.name}`}
   >
-    <h1 class="mb-3">{author.name}</h1>
-    <p class="mb-4">{author.bio}</p>
+    <div class="text-center mb-4">
+      <img
+        src={author.avatar ?? 'https://via.placeholder.com/150'}
+        alt={`${author.name} avatar`}
+        class="rounded-circle mb-3"
+        width="150"
+        height="150"
+        loading="lazy"
+      />
+      <h1 class="mb-3">{author.name}</h1>
+      <p class="mb-4">{author.bio}</p>
+    </div>
     {authorPosts.length > 0 ? (
-      <ul>
+      <div class="row row-cols-1 row-cols-md-2 g-4">
         {authorPosts.map(post => (
-          <li key={post.slug}>
-            <a href={`/blog/${post.slug}`}>{post.title}</a>
-          </li>
+          <div class="col" key={post.slug}>
+            <div class="card bg-dark text-white h-100">
+              <div class="card-body">
+                <h5 class="card-title">
+                  <a href={`/blog/${post.slug}`} class="stretched-link text-white text-decoration-none">
+                    {post.title}
+                  </a>
+                </h5>
+                <p class="mb-1"><small>{post.date}</small></p>
+                <p class="card-text">{post.snippet}</p>
+              </div>
+            </div>
+          </div>
         ))}
-      </ul>
+      </div>
     ) : (
       <p>No posts yet.</p>
     )}
+    <p class="mt-4">
+      <a href="/blog/authors">Back to all authors</a>
+    </p>
   </MainLayout>
 ) : (
   <MainLayout title="Author not found">

--- a/src/pages/blog/authors/index.astro
+++ b/src/pages/blog/authors/index.astro
@@ -1,0 +1,23 @@
+---
+import authors from '../../../data/authors.json';
+import MainLayout from '../../../layouts/MainLayout.astro';
+---
+
+<MainLayout title="Authors" description="Meet the contributors behind MycoSci">
+  <h1 class="mb-4">Our Authors</h1>
+  <div class="row row-cols-1 row-cols-md-2 g-4">
+    {authors.map(a => (
+      <div class="col" key={a.slug}>
+        <div class="card bg-dark text-white h-100">
+          <div class="card-body">
+            <h5 class="card-title">
+              <a href={`/blog/authors/${a.slug}`} class="stretched-link text-white text-decoration-none">{a.name}</a>
+            </h5>
+            <p class="card-text">{a.bio}</p>
+          </div>
+        </div>
+      </div>
+    ))}
+  </div>
+</MainLayout>
+


### PR DESCRIPTION
## Summary
- expand author data with avatar fields
- create an author directory page
- redesign individual author pages with avatars and post cards
- document author directory in README

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8f6aaf2c8323b26892155a5aec75