### PR TITLE
Combine docs & taxonomy with sidebar

### DIFF
--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,0 +1,47 @@
+---
+const { title, description, nav } = Astro.props;
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {description && <meta name="description" content={description} />}
+    <title>{title ? `${title} | MycoSci` : 'MycoSci'}</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
+      crossorigin="anonymous"
+    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body id="top" class="bg-dark text-white d-flex flex-column min-vh-100">
+    <Header />
+    <main class="flex-fill py-4">
+      <div class="container-fluid">
+        <div class="row">
+          <aside class="col-md-3 mb-3">
+            <nav class="nav flex-column">
+              {nav.map(item => (
+                <a href={item.url} class="nav-link text-white" style={`padding-left: ${item.depth}rem`}>{item.title}</a>
+              ))}
+            </nav>
+          </aside>
+          <div class="col-md-9">
+            <slot />
+          </div>
+        </div>
+      </div>
+    </main>
+    <Footer />
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -1,5 +1,6 @@
 ---
-import MainLayout from '../../layouts/MainLayout.astro';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import { getDocsNav } from '../../utils/getDocsNav';
 
 export async function getStaticPaths() {
   const pages = import.meta.glob('../../content/docs/**/*.{md,mdx}');
@@ -19,13 +20,19 @@ const pathBase = '../../content/docs/' + slugPath;
 const mdxPages = import.meta.glob('../../content/docs/**/*.mdx');
 const mdPages = import.meta.glob('../../content/docs/**/*.md');
 let pageImport = mdxPages[pathBase + '.mdx'] || mdPages[pathBase + '.md'];
+let page;
 let Content;
+let pageTitle = 'Docs';
 if (pageImport) {
-  Content = (await pageImport()).default;
+  page = await pageImport();
+  Content = page.default;
+  pageTitle = page.frontmatter?.title ?? pageTitle;
 } else {
   throw new Error(`Document not found: ${pathBase}`);
 }
+
+const nav = getDocsNav();
 ---
-<MainLayout title="Docs">
+<DocsLayout title={pageTitle} nav={nav}>
   <Content />
-</MainLayout>
+</DocsLayout>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,8 +1,11 @@
 ---
-import MainLayout from '../../layouts/MainLayout.astro';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import { getDocsNav } from '../../utils/getDocsNav';
+
+const nav = getDocsNav();
 ---
 
-<MainLayout title="Docs" description="Documentation and guides for MycoSci">
+<DocsLayout title="Docs" description="Documentation and guides for MycoSci" nav={nav}>
   <div class="container my-5">
     <h1 class="mb-4 text-center">MycoSci Documentation</h1>
     <p class="lead text-center">Your free, community-powered field guide to the fungal kingdom.</p>
@@ -44,4 +47,4 @@ import MainLayout from '../../layouts/MainLayout.astro';
       <a href="/docs/quick-start" class="btn btn-primary btn-lg">Quick Start Guide</a>
     </div>
   </div>
-</MainLayout>
+</DocsLayout>

--- a/src/pages/mycopedia.astro
+++ b/src/pages/mycopedia.astro
@@ -23,10 +23,9 @@ import speciesData from '../data/species.json';
     </div>
     <div class="text-center mt-5">
       <a
-        href="/mycopedia/taxonomy/taxonomy-intro"
+        href="/docs/Taxonomy/taxonomy-intro"
         class="btn btn-primary btn-lg"
-        >Explore Taxonomy Docs</a
-      >
+        >Explore Taxonomy Docs</a>
     </div>
   </div>
 </MainLayout>

--- a/src/pages/mycopedia/taxonomy/[...slug].astro
+++ b/src/pages/mycopedia/taxonomy/[...slug].astro
@@ -1,31 +1,11 @@
 ---
-import MainLayout from '../../../layouts/MainLayout.astro';
-
-export async function getStaticPaths() {
-  const pages = import.meta.glob('../../../content/docs/Taxonomy/**/*.{md,mdx}');
-  return Object.keys(pages)
-    .filter((path) => !path.endsWith('/index.mdx'))
-    .map((path) => {
-      const relative = path
-        .replace('../../../content/docs/Taxonomy/', '')
-        .replace(/\.(md|mdx)$/, '');
-      return { params: { slug: relative } };
-    });
-}
-
-const slugParam = Astro.params.slug;
-const slugPath = Array.isArray(slugParam) ? slugParam.join('/') : slugParam;
-const pathBase = '../../../content/docs/Taxonomy/' + slugPath;
-const mdxPages = import.meta.glob('../../../content/docs/Taxonomy/**/*.mdx');
-const mdPages = import.meta.glob('../../../content/docs/Taxonomy/**/*.md');
-let pageImport = mdxPages[pathBase + '.mdx'] || mdPages[pathBase + '.md'];
-let Content;
-if (pageImport) {
-  Content = (await pageImport()).default;
-} else {
-  throw new Error(`Document not found: ${pathBase}`);
-}
 ---
-<MainLayout title="Taxonomy">
-  <Content />
-</MainLayout>
+<html>
+  <head>
+    <script>
+      const slug = Array.isArray(Astro.params.slug) ? Astro.params.slug.join('/') : Astro.params.slug;
+      window.location.href = '/docs/' + slug;
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/pages/mycopedia/taxonomy/index.astro
+++ b/src/pages/mycopedia/taxonomy/index.astro
@@ -1,7 +1,8 @@
 ---
-import TaxoDoc from '../../../content/docs/Taxonomy/taxonomy-intro.md';
-import MainLayout from '../../../layouts/MainLayout.astro';
 ---
-<MainLayout title="Taxonomy">
-  <TaxoDoc />
-</MainLayout>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=/docs/Taxonomy/taxonomy-intro" />
+  </head>
+  <body></body>
+</html>

--- a/src/utils/getDocsNav.ts
+++ b/src/utils/getDocsNav.ts
@@ -1,0 +1,19 @@
+export interface NavItem {
+  url: string;
+  title: string;
+  depth: number;
+}
+
+export function getDocsNav(): NavItem[] {
+  const pages = import.meta.glob('../content/docs/**/*.{md,mdx}', { eager: true }) as Record<string, any>;
+  return Object.entries(pages)
+    .map(([path, mod]) => {
+      const slug = path
+        .replace('../content/docs/', '')
+        .replace(/\.(md|mdx)$/, '');
+      const depth = slug.split('/').length - 1;
+      const title = mod.frontmatter?.title ?? slug.split('/').pop();
+      return { url: '/docs/' + slug, title, depth };
+    })
+    .sort((a, b) => a.url.localeCompare(b.url));
+}


### PR DESCRIPTION
## Summary
- build new `DocsLayout` with sidebar nav
- generate docs navigation automatically in `getDocsNav`
- swap docs pages to use `DocsLayout`
- redirect old taxonomy pages to new docs paths
- update Mycopedia link to taxonomy docs

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8f9942248323a54a1ae2449365df