### PR TITLE
Improve docs and taxonomy flow

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -11,6 +11,7 @@
         <li class="nav-item"><a class="nav-link" href="/explore">Explore</a></li>
         <li class="nav-item"><a class="nav-link" href="/gallery">Gallery</a></li>
         <li class="nav-item"><a class="nav-link" href="/mycopedia">MycoPedia</a></li>
+        <li class="nav-item"><a class="nav-link" href="/docs">Docs</a></li>
         <li class="nav-item"><a class="nav-link" href="/blog">Blog</a></li>
         <li class="nav-item"><a class="nav-link" href="/lab">Lab &amp; Cultivation</a></li>
         <li class="nav-item"><a class="nav-link" href="/community">Community</a></li>

--- a/src/content/docs/Guides/quick-start.md
+++ b/src/content/docs/Guides/quick-start.md
@@ -7,6 +7,8 @@ Welcome to **MycoSci**, your free, open-source hub dedicated to the science, cul
 
 Our docs are organized scientifically, practically, and intuitively, helping you navigate from detailed species references to hands-on cultivation techniques and field guides.
 
+If you're looking for a deep dive into classification, start in the [Taxonomy section](../Taxonomy/).
+
 ## How to Navigate the Docs
 
 ### 📖 **Taxonomy (Scientific Reference)**
@@ -37,6 +39,13 @@ Start safely in the [Foraging Guide](../foraging/getting-started).
 Guides to setting up a functional mushroom lab—covering gear for beginners and specialized equipment for professional mycologists.
 
 Visit our [Lab Setup & Equipment](../equipment/beginner-lab-setup) page to see what's needed.
+
+---
+
+### 🍽️ **Culinary Recipes**
+Discover tasty ways to cook your harvest or cultivated mushrooms.
+
+Browse our [Recipe Collection](../recipes/intro) for inspiration.
 
 ---
 

--- a/src/content/docs/Taxonomy/index.mdx
+++ b/src/content/docs/Taxonomy/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Taxonomy Overview
+description: Navigate the fungal tree of life from phylum to species.
+---
+
+import { LinkButton } from '@astrojs/starlight/components';
+
+# Fungal Taxonomy
+
+Begin exploring the major fungal lineages:
+
+- [Ascomycota](./Ascomycota/)
+- [Basidiomycota](./Basidiomycota/)
+
+<LinkButton href="./taxonomy-intro" variant="primary">Read the introduction</LinkButton>

--- a/src/content/docs/Taxonomy/taxonomy-intro.md
+++ b/src/content/docs/Taxonomy/taxonomy-intro.md
@@ -113,6 +113,8 @@ Start Your Journey!
 
 Dive deep into MycoSci's extensive taxonomy documentation, discover intriguing fungal species, and enjoy your exploration of the fungal kingdom.
 
+For cultivation guides, lab techniques, and recipes, head back to the [main docs](../index).
+
 Happy exploring and learning! 🍄🌿
 
 --- **The MycoSci Team**

--- a/src/content/docs/chemistry-nutrition/mushroom-nutrition.md
+++ b/src/content/docs/chemistry-nutrition/mushroom-nutrition.md
@@ -1,0 +1,6 @@
+---
+title: Mushroom Nutrition Overview
+description: Key vitamins, minerals, and medicinal compounds found in fungi.
+---
+
+Mushrooms contain a variety of nutrients from vitamin D to unique polysaccharides. This page summarizes the major components studied in common edible and medicinal species.

--- a/src/content/docs/cultivation/beginner/pf-tek.md
+++ b/src/content/docs/cultivation/beginner/pf-tek.md
@@ -1,0 +1,8 @@
+---
+title: PF-Tek Beginner Guide
+description: Simple method for cultivating mushrooms using brown rice flour cakes.
+---
+
+The **PF-Tek** (Psilocybe Fanaticus Technique) is a tried-and-true approach for cultivating small batches of mushrooms. It uses jars filled with brown rice flour and vermiculite to grow compact cakes that can be fruited in a simple tub.
+
+Stay tuned for a step-by-step walkthrough.

--- a/src/content/docs/equipment/beginner-lab-setup.md
+++ b/src/content/docs/equipment/beginner-lab-setup.md
@@ -1,0 +1,6 @@
+---
+title: Beginner Lab Setup
+description: Essential equipment for starting a small-scale mushroom lab.
+---
+
+Setting up a simple lab space greatly improves your success with sterile work. This guide outlines affordable tools like pressure cookers, still-air boxes, and basic agar techniques.

--- a/src/content/docs/foraging/getting-started.md
+++ b/src/content/docs/foraging/getting-started.md
@@ -1,0 +1,6 @@
+---
+title: Getting Started Foraging
+description: Safety tips for new mushroom hunters.
+---
+
+Before harvesting wild mushrooms, learn the fundamentals of identification and always verify with multiple sources. This primer covers ethical collecting, field gear, and common pitfalls.

--- a/src/content/docs/lab/intro.md
+++ b/src/content/docs/lab/intro.md
@@ -1,0 +1,6 @@
+---
+title: Lab Techniques Overview
+description: Start here for sterile work and advanced cultivation protocols.
+---
+
+Welcome to the lab section. Here you'll find guides on agar work, cloning, and setting up controlled environments for research or gourmet production.

--- a/src/content/docs/recipes/intro.md
+++ b/src/content/docs/recipes/intro.md
@@ -1,0 +1,6 @@
+---
+title: Mushroom Recipes
+description: Delicious ways to prepare wild and cultivated fungi.
+---
+
+From simple sautés to gourmet fare, this section collects crowd-pleasing mushroom dishes. Share your own recipes with the community!

--- a/src/content/docs/references/historical-literature.md
+++ b/src/content/docs/references/historical-literature.md
@@ -1,0 +1,6 @@
+---
+title: Historical Literature
+description: Classic mycology texts and research archives.
+---
+
+A curated list of freely available books and papers that shaped the field of mycology. Explore seminal works dating back to the 19th century.

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -11,36 +11,64 @@ const nav = getDocsNav();
     <p class="lead text-center">Your free, community-powered field guide to the fungal kingdom.</p>
     <div class="row row-cols-1 row-cols-md-2 g-4 mt-4">
       <div class="col">
-        <div class="card h-100 bg-dark text-white">
-          <div class="card-body">
-            <h5 class="card-title">Field Guide</h5>
-            <p class="card-text">Identify over 500 species with photos and look-alike warnings.</p>
+        <a href="/docs/Taxonomy/" class="text-decoration-none">
+          <div class="card h-100 bg-dark text-white">
+            <div class="card-body">
+              <h5 class="card-title">Field Guide</h5>
+              <p class="card-text">Browse taxonomy from phylum down to individual species.</p>
+            </div>
           </div>
-        </div>
+        </a>
       </div>
       <div class="col">
-        <div class="card h-100 bg-dark text-white">
-          <div class="card-body">
-            <h5 class="card-title">Cultivation Basics</h5>
-            <p class="card-text">Step-by-step monotub, PF-tek, and gourmet log methods.</p>
+        <a href="/docs/cultivation/beginner/pf-tek" class="text-decoration-none">
+          <div class="card h-100 bg-dark text-white">
+            <div class="card-body">
+              <h5 class="card-title">Cultivation Basics</h5>
+              <p class="card-text">Step-by-step monotub, PF-tek, and gourmet log methods.</p>
+            </div>
           </div>
-        </div>
+        </a>
       </div>
       <div class="col">
-        <div class="card h-100 bg-dark text-white">
-          <div class="card-body">
-            <h5 class="card-title">Advanced Lab Protocols</h5>
-            <p class="card-text">Agar cloning, liquid culture, and sterile technique.</p>
+        <a href="/docs/lab/intro" class="text-decoration-none">
+          <div class="card h-100 bg-dark text-white">
+            <div class="card-body">
+              <h5 class="card-title">Lab Techniques</h5>
+              <p class="card-text">Agar cloning, liquid culture, and sterile technique.</p>
+            </div>
           </div>
-        </div>
+        </a>
       </div>
       <div class="col">
-        <div class="card h-100 bg-dark text-white">
-          <div class="card-body">
-            <h5 class="card-title">Research Library</h5>
-            <p class="card-text">Curated papers, genome data sets, and historic texts.</p>
+        <a href="/docs/recipes/intro" class="text-decoration-none">
+          <div class="card h-100 bg-dark text-white">
+            <div class="card-body">
+              <h5 class="card-title">Recipes</h5>
+              <p class="card-text">Culinary ideas for cooking wild and cultivated fungi.</p>
+            </div>
           </div>
-        </div>
+        </a>
+      </div>
+      <div class="col">
+        <a href="/docs/chemistry-nutrition/mushroom-nutrition" class="text-decoration-none">
+          <div class="card h-100 bg-dark text-white">
+            <div class="card-body">
+              <h5 class="card-title">Nutrition & Chemistry</h5>
+              <p class="card-text">Explore medicinal compounds and health benefits.</p>
+            </div>
+          </div>
+        </a>
+      </div>
+      <div class="col">
+        <a href="/docs/references/historical-literature" class="text-decoration-none">
+          <div class="card h-100 bg-dark text-white">
+            <div class="card-body">
+              <h5 class="card-title">Research Library</h5>
+              <p class="card-text">Curated papers, genome data sets, and historic texts.</p>
+            </div>
+          </div>
+        </a>
       </div>
     </div>
     <div class="text-center mt-5">

--- a/src/pages/mycopedia.astro
+++ b/src/pages/mycopedia.astro
@@ -23,7 +23,7 @@ import speciesData from '../data/species.json';
     </div>
     <div class="text-center mt-5">
       <a
-        href="/docs/Taxonomy/taxonomy-intro"
+        href="/docs/Taxonomy/"
         class="btn btn-primary btn-lg"
         >Explore Taxonomy Docs</a>
     </div>


### PR DESCRIPTION
## Summary
- link docs from site header
- expand docs landing page with taxonomy, lab, recipes and more
- add placeholder docs for cultivation, lab setup, nutrition, foraging, and recipes
- provide taxonomy index and link back to docs
- update quick-start and mycopedia pages for new paths

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683e9f54b8948323a138777ff69713bb