### PR TITLE
Add live species search

### DIFF
--- a/src/components/SearchBox.astro
+++ b/src/components/SearchBox.astro
@@ -1,0 +1,31 @@
+---
+const { data } = Astro.props;
+---
+<form class="d-flex justify-content-center mb-2" role="search" onsubmit="event.preventDefault()">
+  <input id="searchInput" class="form-control form-control-lg w-50 me-2" type="search" placeholder="Search species" aria-label="Search" autocomplete="off" />
+</form>
+<div id="searchResults" class="list-group"></div>
+
+<script type="module" data-species={JSON.stringify(data)}>
+  const data = JSON.parse(document.currentScript.dataset.species);
+  const input = document.querySelector('#searchInput');
+  const results = document.querySelector('#searchResults');
+  const render = () => {
+    const q = input.value.trim().toLowerCase();
+    if (!q) {
+      results.innerHTML = '';
+      return;
+    }
+    const matches = data.filter(
+      (sp) =>
+        sp.common_name.toLowerCase().includes(q) ||
+        sp.scientific_name.toLowerCase().includes(q)
+    );
+    results.innerHTML = matches
+      .map(
+        (sp) => `<a href="/species/${sp.slug}" class="list-group-item list-group-item-action">${sp.common_name} <span class="fst-italic text-muted">${sp.scientific_name}</span></a>`
+      )
+      .join('');
+  };
+  input.addEventListener('input', render);
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
 import speciesData from '../data/species.json';
+import SearchBox from '../components/SearchBox.astro';
 const featured = speciesData.slice(0, 4);
 ---
 
@@ -8,10 +9,7 @@ const featured = speciesData.slice(0, 4);
   <header class="hero text-white text-center mb-5">
     <div class="container py-5">
       <h1 class="display-3 fw-bold mb-4">Mapping the Mycological Universe, One Spore at a Time.</h1>
-      <form class="d-flex justify-content-center" role="search">
-        <input class="form-control form-control-lg w-50 me-2" type="search" placeholder="Search species" aria-label="Search" />
-        <button class="btn btn-primary btn-lg" type="submit">Search</button>
-      </form>
+      <SearchBox data={speciesData} />
     </div>
   </header>
   <main class="container">


### PR DESCRIPTION
## Summary
- add `SearchBox` component for instant filtering of mushroom species
- use `SearchBox` on the home page

Build output shows the site compiles successfully.

## Testing
- `npx prettier --write src/components/SearchBox.astro src/pages/index.astro` *(fails: No parser could be inferred)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683facf01a4c8323b1cd2c09cee3062c