### PR TITLE
Add forum scaffolding

### DIFF
--- a/src/components/Forum.astro
+++ b/src/components/Forum.astro
@@ -1,0 +1,26 @@
+---
+import threads from '../data/forum.json';
+import authors from '../data/authors.json';
+
+function getAuthor(slug) {
+  return authors.find(a => a.slug === slug) ?? { name: slug };
+}
+---
+<section class="mb-5">
+  <h2 class="mb-4">Forum</h2>
+  <div class="list-group">
+    {threads.map(thread => (
+      <a
+        href="#"
+        class="list-group-item list-group-item-action bg-dark text-white"
+        key={thread.id}
+      >
+        <div class="d-flex w-100 justify-content-between">
+          <h5 class="mb-1">{thread.title}</h5>
+          <small>{thread.replies} replies</small>
+        </div>
+        <small>Started by {getAuthor(thread.author).name}</small>
+      </a>
+    ))}
+  </div>
+</section>

--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -1,0 +1,22 @@
+---
+import leaders from '../data/leaderboard.json';
+import authors from '../data/authors.json';
+
+function getName(slug) {
+  return authors.find(a => a.slug === slug)?.name ?? slug;
+}
+---
+<section class="mb-5">
+  <h2 class="mb-4">Leaderboard</h2>
+  <ol class="list-group list-group-numbered">
+    {leaders.map(l => (
+      <li
+        class="list-group-item bg-dark text-white d-flex justify-content-between align-items-center"
+        key={l.username}
+      >
+        <span>{getName(l.username)}</span>
+        <span class="badge bg-primary rounded-pill">{l.points}</span>
+      </li>
+    ))}
+  </ol>
+</section>

--- a/src/components/ProfileCard.astro
+++ b/src/components/ProfileCard.astro
@@ -1,0 +1,17 @@
+---
+const { user } = Astro.props;
+---
+<div class="card bg-dark text-white">
+  <div class="card-body text-center">
+    <img
+      src={user.avatar ?? 'https://via.placeholder.com/150'}
+      alt={`${user.name} avatar`}
+      class="rounded-circle mb-3"
+      width="150"
+      height="150"
+      loading="lazy"
+    />
+    <h5 class="card-title">{user.name}</h5>
+    <p class="card-text">{user.bio}</p>
+  </div>
+</div>

--- a/src/components/SignInForm.astro
+++ b/src/components/SignInForm.astro
@@ -1,0 +1,13 @@
+---
+---
+<form class="bg-dark p-4 rounded">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" id="username" class="form-control" />
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" id="password" class="form-control" />
+  </div>
+  <button type="submit" class="btn btn-primary">Sign In</button>
+</form>

--- a/src/data/forum.json
+++ b/src/data/forum.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "title": "Best methods for oyster cultivation?",
+    "author": "asmith",
+    "replies": 4
+  },
+  {
+    "id": 2,
+    "title": "Share your favorite mushroom photos",
+    "author": "jdoe",
+    "replies": 8
+  }
+]

--- a/src/data/leaderboard.json
+++ b/src/data/leaderboard.json
@@ -1,0 +1,5 @@
+[
+  { "username": "asmith", "points": 120 },
+  { "username": "jdoe", "points": 90 },
+  { "username": "guest", "points": 45 }
+]

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,11 +1,18 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import Forum from '../components/Forum.astro';
+import Leaderboard from '../components/Leaderboard.astro';
 ---
 
 <MainLayout title="Community" description="Forums and events for mushroom enthusiasts">
-  <div class="container my-5">
-    <h1 class="mb-4 text-center">Community</h1>
-    <p class="lead text-center">Join discussions, share photos, and take part in events.</p>
-    <p class="text-center">Forums and challenges are coming soon.</p>
-  </div>
+  <header class="text-center mb-5">
+    <h1 class="display-4 fw-bold">Community</h1>
+    <p class="lead">Connect with other mycologists, share knowledge, and climb the leaderboard.</p>
+    <p>
+      <a href="/community/signin" class="btn btn-primary me-2">Sign In</a>
+      <a href="/community/profile" class="btn btn-outline-light">View Profile</a>
+    </p>
+  </header>
+  <Forum />
+  <Leaderboard />
 </MainLayout>

--- a/src/pages/community/profile.astro
+++ b/src/pages/community/profile.astro
@@ -1,0 +1,16 @@
+---
+import MainLayout from '../../layouts/MainLayout.astro';
+import ProfileCard from '../../components/ProfileCard.astro';
+import authors from '../../data/authors.json';
+
+const user = authors[0];
+---
+
+<MainLayout title="Your Profile">
+  <h1 class="mb-4 text-center">Profile</h1>
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <ProfileCard user={user} />
+    </div>
+  </div>
+</MainLayout>

--- a/src/pages/community/signin.astro
+++ b/src/pages/community/signin.astro
@@ -1,0 +1,16 @@
+---
+import MainLayout from '../../layouts/MainLayout.astro';
+import SignInForm from '../../components/SignInForm.astro';
+---
+
+<MainLayout title="Sign In">
+  <div class="text-center mb-4">
+    <h1>Sign In</h1>
+    <p class="lead">Access the MycoSci community forum.</p>
+  </div>
+  <div class="row justify-content-center">
+    <div class="col-md-6">
+      <SignInForm />
+    </div>
+  </div>
+</MainLayout>


### PR DESCRIPTION
## Summary
- add forum component and leaderboard
- scaffold sign-in and profile pages
- wire up community home to show forum and leaderboard

## Testing
- `npx prettier --write src/components/Forum.astro src/components/Leaderboard.astro src/components/ProfileCard.astro src/components/SignInForm.astro src/pages/community.astro src/pages/community/profile.astro src/pages/community/signin.astro`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fad84d3b4832394cee74dc44e1b8a