### PR TITLE
Organize community components by taxonomy

### DIFF
--- a/src/components/Forum.astro
+++ b/src/components/Forum.astro
@@ -1,26 +1,55 @@
 ---
 import threads from '../data/forum.json';
 import authors from '../data/authors.json';
+import speciesList from '../data/species.json';
 
 function getAuthor(slug) {
   return authors.find(a => a.slug === slug) ?? { name: slug };
 }
+
+function getSpecies(slug) {
+  return (
+    speciesList.find((s) => s.slug === slug) ?? {
+      slug,
+      common_name: slug,
+      phylum: 'Unknown',
+    }
+  );
+}
+
+const grouped = {};
+for (const t of threads) {
+  const sp = getSpecies(t.species);
+  if (!grouped[sp.phylum]) grouped[sp.phylum] = {};
+  if (!grouped[sp.phylum][sp.slug]) grouped[sp.phylum][sp.slug] = [];
+  grouped[sp.phylum][sp.slug].push(t);
+}
 ---
 <section class="mb-5">
   <h2 class="mb-4">Forum</h2>
-  <div class="list-group">
-    {threads.map(thread => (
-      <a
-        href="#"
-        class="list-group-item list-group-item-action bg-dark text-white"
-        key={thread.id}
-      >
-        <div class="d-flex w-100 justify-content-between">
-          <h5 class="mb-1">{thread.title}</h5>
-          <small>{thread.replies} replies</small>
+  {Object.entries(grouped).map(([phylum, bySpecies]) => (
+    <div class="mb-4" key={phylum}>
+      <h3 class="h4">{phylum} Gym</h3>
+      {Object.entries(bySpecies).map(([slug, posts]) => (
+        <div class="mb-3" key={slug}>
+          <h4 class="h5">{getSpecies(slug).common_name}</h4>
+          <div class="list-group">
+            {posts.map((thread) => (
+              <a
+                href="#"
+                class="list-group-item list-group-item-action bg-dark text-white"
+                key={thread.id}
+              >
+                <div class="d-flex w-100 justify-content-between">
+                  <h5 class="mb-1">{thread.title}</h5>
+                  <small>{thread.replies} replies</small>
+                </div>
+                <small>Started by {getAuthor(thread.author).name}</small>
+              </a>
+            ))}
+          </div>
         </div>
-        <small>Started by {getAuthor(thread.author).name}</small>
-      </a>
-    ))}
-  </div>
+      ))}
+    </div>
+  ))}
 </section>

--- a/src/components/Leaderboard.astro
+++ b/src/components/Leaderboard.astro
@@ -1,22 +1,43 @@
 ---
 import leaders from '../data/leaderboard.json';
 import authors from '../data/authors.json';
+import speciesList from '../data/species.json';
 
 function getName(slug) {
   return authors.find(a => a.slug === slug)?.name ?? slug;
 }
+
+function getSpecies(slug) {
+  return (
+    speciesList.find((s) => s.slug === slug) ?? {
+      common_name: slug,
+      slug,
+    }
+  );
+}
+
+const grouped = {};
+for (const entry of leaders) {
+  if (!grouped[entry.species]) grouped[entry.species] = [];
+  grouped[entry.species].push(entry);
+}
 ---
 <section class="mb-5">
   <h2 class="mb-4">Leaderboard</h2>
-  <ol class="list-group list-group-numbered">
-    {leaders.map(l => (
-      <li
-        class="list-group-item bg-dark text-white d-flex justify-content-between align-items-center"
-        key={l.username}
-      >
-        <span>{getName(l.username)}</span>
-        <span class="badge bg-primary rounded-pill">{l.points}</span>
-      </li>
-    ))}
-  </ol>
+  {Object.entries(grouped).map(([slug, entries]) => (
+    <div class="mb-4" key={slug}>
+      <h3 class="h5">{getSpecies(slug).common_name} Gym</h3>
+      <ol class="list-group list-group-numbered">
+        {entries.map((l) => (
+          <li
+            class="list-group-item bg-dark text-white d-flex justify-content-between align-items-center"
+            key={l.username}
+          >
+            <span>{getName(l.username)}</span>
+            <span class="badge bg-primary rounded-pill">{l.points}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  ))}
 </section>

--- a/src/data/forum.json
+++ b/src/data/forum.json
@@ -3,12 +3,14 @@
     "id": 1,
     "title": "Best methods for oyster cultivation?",
     "author": "asmith",
-    "replies": 4
+    "replies": 4,
+    "species": "pleurotus-ostreatus"
   },
   {
     "id": 2,
     "title": "Share your favorite mushroom photos",
     "author": "jdoe",
-    "replies": 8
+    "replies": 8,
+    "species": "amanita-muscaria"
   }
 ]

--- a/src/data/leaderboard.json
+++ b/src/data/leaderboard.json
@@ -1,5 +1,17 @@
 [
-  { "username": "asmith", "points": 120 },
-  { "username": "jdoe", "points": 90 },
-  { "username": "guest", "points": 45 }
+  {
+    "username": "asmith",
+    "points": 120,
+    "species": "pleurotus-ostreatus"
+  },
+  {
+    "username": "jdoe",
+    "points": 90,
+    "species": "amanita-muscaria"
+  },
+  {
+    "username": "guest",
+    "points": 45,
+    "species": "amanita-muscaria"
+  }
 ]

--- a/src/data/species.json
+++ b/src/data/species.json
@@ -3,12 +3,14 @@
     "slug": "amanita-muscaria",
     "common_name": "Fly Agaric",
     "scientific_name": "Amanita muscaria",
+    "phylum": "Basidiomycota",
     "description": "Iconic red mushroom with white spots, known for its psychoactive properties."
   },
   {
     "slug": "pleurotus-ostreatus",
     "common_name": "Oyster Mushroom",
     "scientific_name": "Pleurotus ostreatus",
+    "phylum": "Ascomycota",
     "description": "Edible mushroom widely cultivated and found on decaying wood."
   }
 ]


### PR DESCRIPTION
## Summary
- extend species data with `phylum`
- associate threads and leaderboard entries with a species
- group forum threads by species and phylum
- show leaderboard rankings per species gym

## Testing
- `npx prettier --write src/data/forum.json src/data/leaderboard.json src/data/species.json`
- `npx prettier --write src/components/Forum.astro` *(fails: No parser could be inferred)*
- `npx prettier --write src/components/Leaderboard.astro` *(fails: No parser could be inferred)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fb0e6c55c83239d585e2adb281826