### PR TITLE
style: refresh docs and lab ui

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -174,62 +174,22 @@ li {
 }
 
 .site-header {
-  background: transparent;
-  margin-bottom: 2rem;
-}
-
-.site-header__band {
-  background: linear-gradient(
-    90deg,
-    rgba(11, 61, 145, 0.08) 0%,
-    rgba(11, 61, 145, 0.08) 65%,
-    transparent 65%
-  );
+  background: #fff;
   border-bottom: 1px solid var(--nasa-border);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.68rem;
-  letter-spacing: 0.24em;
-  padding: 0.65rem 0;
+  box-shadow: 0 8px 24px rgba(11, 61, 145, 0.08);
+  margin-bottom: 2rem;
   position: relative;
+  z-index: 100;
+}
+
+.site-navbar {
+  background: transparent;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
-.site-header__band::after {
-  background: linear-gradient(
-    90deg,
-    var(--nasa-blue) 0%,
-    var(--nasa-blue) 70%,
-    var(--nasa-red) 70%,
-    var(--nasa-red) 100%
-  );
-  content: "";
-  height: 3px;
-  left: 0;
-  position: absolute;
-  bottom: -3px;
-  width: 128px;
-}
-
-.site-header__band-label {
-  color: var(--nasa-blue);
-}
-
-.site-header__band-meta {
-  color: var(--nasa-slate);
-  opacity: 0.8;
-}
-
-.nasa-navbar {
-  background-color: #fff;
-  border-bottom: 3px solid var(--nasa-blue);
-  border-top: 1px solid var(--nasa-border);
-  box-shadow: 0 12px 0 -10px var(--nasa-band-muted);
-  font-size: 0.78rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-}
-
-.nasa-navbar .navbar-brand {
+.site-navbar__brand {
   align-items: flex-start;
   color: var(--nasa-blue);
   display: flex;
@@ -239,14 +199,15 @@ li {
   letter-spacing: 0.24em;
   line-height: 1;
   text-transform: uppercase;
+  transition: color 0.2s ease;
 }
 
-.nasa-navbar .navbar-brand:hover,
-.nasa-navbar .navbar-brand:focus {
+.site-navbar__brand:hover,
+.site-navbar__brand:focus {
   color: var(--nasa-red);
 }
 
-.navbar-brand__wordmark {
+.site-navbar__wordmark {
   font-family: "Barlow Condensed", "Helvetica Neue", Arial, sans-serif;
   font-size: 1.85rem;
   letter-spacing: 0.28em;
@@ -254,53 +215,166 @@ li {
   text-transform: uppercase;
 }
 
-.navbar-brand__sub {
+.site-navbar__sub {
   color: var(--nasa-slate);
   font-family: "IBM Plex Mono", monospace;
   font-size: 0.65rem;
   letter-spacing: 0.28em;
 }
 
-.nasa-navbar .nav-link {
+.site-navbar .nav-link {
+  border-bottom: 2px solid transparent;
   color: var(--nasa-ink);
   font-family: "IBM Plex Mono", monospace;
   font-weight: 500;
-  padding: 0.75rem 1.2rem;
-  position: relative;
+  padding: 0.75rem 1rem;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    background-color 0.2s ease;
 }
 
-.nasa-navbar .nav-link::after {
-  background: linear-gradient(90deg, var(--nasa-blue) 0%, var(--nasa-red) 100%);
-  bottom: 0.35rem;
-  content: "";
-  height: 2px;
-  left: 0;
-  position: absolute;
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.2s ease;
-  width: 100%;
-}
-
-.nasa-navbar .nav-link:hover,
-.nasa-navbar .nav-link:focus {
+.site-navbar .nav-link:hover,
+.site-navbar .nav-link:focus {
+  background-color: rgba(11, 61, 145, 0.08);
+  border-bottom-color: var(--nasa-blue);
   color: var(--nasa-blue);
 }
 
-.nasa-navbar .nav-link:hover::after,
-.nasa-navbar .nav-link:focus::after,
-.nasa-navbar .nav-link.active::after {
-  transform: scaleX(1);
+.site-navbar .nav-link.active,
+.site-navbar .nav-link[aria-current="page"] {
+  border-bottom-color: var(--nasa-red);
+  color: var(--nasa-blue);
+  font-weight: 600;
 }
 
-.nasa-navbar .navbar-toggler {
+.site-navbar .navbar-toggler {
   border: 2px solid var(--nasa-blue);
   border-radius: 0;
   padding: 0.4rem 0.6rem;
 }
 
-.nasa-navbar .navbar-toggler-icon {
+.site-navbar .navbar-toggler-icon {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba(11, 61, 145, 1)' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.docs-landing header p {
+  margin: 0 auto;
+  max-width: 560px;
+}
+
+.docs-sidenav {
+  background: #fff;
+  border: 1px solid var(--nasa-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 40px rgba(11, 61, 145, 0.12);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 7rem);
+  overflow-y: auto;
+  padding: 0.75rem 0;
+  position: sticky;
+  top: 6.5rem;
+}
+
+.docs-sidenav__link {
+  border-left: 3px solid transparent;
+  color: var(--nasa-ink);
+  display: block;
+  font-family: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+  font-size: 0.95rem;
+  font-weight: 500;
+  padding: 0.5rem 1.25rem;
+  padding-left: calc(1.25rem + (var(--nav-depth, 0) * 0.75rem));
+  text-transform: none;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.docs-sidenav__link:hover,
+.docs-sidenav__link:focus {
+  background-color: var(--nasa-ivory);
+  border-left-color: rgba(11, 61, 145, 0.25);
+  color: var(--nasa-blue);
+}
+
+.docs-sidenav__link.active {
+  background-color: var(--nasa-panel);
+  border-left-color: var(--nasa-blue);
+  color: var(--nasa-blue);
+  font-weight: 600;
+}
+
+.docs-content {
+  background: #fff;
+  border: 1px solid var(--nasa-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 24px 48px rgba(11, 61, 145, 0.12);
+  padding: clamp(1.75rem, 2vw + 1.25rem, 3rem);
+}
+
+.docs-content > :first-child {
+  margin-top: 0;
+}
+
+.docs-content > :last-child {
+  margin-bottom: 0;
+}
+
+.docs-card {
+  background: #fff;
+  border: 1px solid var(--nasa-border);
+  border-radius: 0.75rem;
+  display: block;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.docs-card:hover,
+.docs-card:focus {
+  box-shadow: 0 18px 36px rgba(11, 61, 145, 0.12);
+  transform: translateY(-4px);
+}
+
+.docs-card .card-title {
+  color: var(--nasa-ink);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.docs-plan {
+  background: var(--nasa-panel);
+  border: 1px solid var(--nasa-border);
+  border-radius: 0.75rem;
+}
+
+.docs-plan__module {
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(11, 61, 145, 0.18);
+  border-radius: 0.65rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.65);
+  height: 100%;
+  padding: 1.25rem 1.35rem;
+}
+
+.docs-plan__module h3 {
+  color: var(--nasa-blue);
+  letter-spacing: 0.14em;
+  margin-bottom: 0.75rem;
+}
+
+.docs-plan__list {
+  color: var(--nasa-slate);
+  margin: 0;
+  list-style: disc;
+  padding-left: 1.1rem;
+}
+
+.docs-plan__list li + li {
+  margin-top: 0.5rem;
 }
 
 .hero {
@@ -937,10 +1011,6 @@ li {
     margin-bottom: 1.5rem;
   }
 
-  .site-header__band::after {
-    width: 96px;
-  }
-
   .hero__inner {
     grid-template-columns: 1fr;
   }
@@ -949,12 +1019,18 @@ li {
     margin-top: 1.5rem;
   }
 
-  .nasa-navbar {
+  .site-navbar {
     font-size: 0.75rem;
   }
 
-  .nasa-navbar .nav-link {
-    padding-left: 0;
+  .site-navbar .nav-link {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+
+  .docs-sidenav {
+    max-height: none;
+    position: static;
   }
 }
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,17 +1,21 @@
 ---
+const navLinks = [
+  { href: '/gallery', label: 'Gallery' },
+  { href: '/mycopedia', label: 'MycoPedia' },
+  { href: '/blog', label: 'Blog' },
+  { href: '/lab', label: 'Lab & Cultivation' },
+];
+
+const normalize = (value: string) => (value.endsWith('/') ? value : value + '/');
+const currentPath = normalize(Astro.url.pathname);
+const isActive = (href: string) => currentPath.startsWith(normalize(href));
 ---
 <header class="site-header">
-  <div class="site-header__band">
-    <div class="container d-flex flex-wrap align-items-center justify-content-between gap-3">
-      <span class="site-header__band-label">MycoSci Mission Operations</span>
-      <span class="site-header__band-meta">Revision 3.2 // Status: Nominal</span>
-    </div>
-  </div>
-  <nav class="navbar navbar-expand-lg navbar-light nasa-navbar">
+  <nav class="navbar navbar-expand-lg site-navbar" aria-label="Primary navigation">
     <div class="container">
-      <a class="navbar-brand" href="/">
-        <span class="navbar-brand__wordmark">MycoSci</span>
-        <span class="navbar-brand__sub">Mycology Systems Division</span>
+      <a class="navbar-brand site-navbar__brand" href="/">
+        <span class="site-navbar__wordmark">MycoSci</span>
+        <span class="site-navbar__sub">Mycology Systems Division</span>
       </a>
       <button
         class="navbar-toggler"
@@ -26,10 +30,20 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item"><a class="nav-link" href="/gallery">Gallery</a></li>
-          <li class="nav-item"><a class="nav-link" href="/mycopedia">MycoPedia</a></li>
-          <li class="nav-item"><a class="nav-link" href="/blog">Blog</a></li>
-          <li class="nav-item"><a class="nav-link" href="/lab">Lab &amp; Cultivation</a></li>
+          {navLinks.map(link => {
+            const active = isActive(link.href);
+            return (
+              <li class="nav-item">
+                <a
+                  class={`nav-link${active ? ' active' : ''}`}
+                  href={link.href}
+                  aria-current={active ? 'page' : undefined}
+                >
+                  {link.label}
+                </a>
+              </li>
+            );
+          })}
         </ul>
         <form class="d-none d-lg-flex" role="search">
           <label class="visually-hidden" for="header-search">Search the catalog</label>
@@ -40,7 +54,7 @@
             placeholder="Species, labs, posts"
             aria-label="Search"
           />
-          <button class="btn btn-outline-primary btn-sm" type="submit">Execute</button>
+          <button class="btn btn-outline-primary btn-sm" type="submit">Search</button>
         </form>
       </div>
     </div>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -2,6 +2,9 @@
 const { title, description, nav } = Astro.props;
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+
+const normalize = (value: string) => (value.endsWith('/') ? value : value + '/');
+const currentPath = normalize(Astro.url.pathname);
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -10,6 +13,12 @@ import Footer from '../components/Footer.astro';
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     {description && <meta name="description" content={description} />}
     <title>{title ? `${title} | MycoSci` : 'MycoSci'}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
       rel="stylesheet"
@@ -19,20 +28,33 @@ import Footer from '../components/Footer.astro';
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body id="top" class="bg-dark text-white d-flex flex-column min-vh-100">
+  <body id="top" class="nasa-body d-flex flex-column min-vh-100">
     <Header />
-    <main class="flex-fill py-4">
-      <div class="container-fluid">
-        <div class="row">
-          <aside class="col-md-3 mb-3">
-            <nav class="nav flex-column">
-              {nav.map(item => (
-                <a href={item.url} class="nav-link text-white" style={`padding-left: ${item.depth}rem`}>{item.title}</a>
-              ))}
+    <main class="flex-fill py-5">
+      <div class="container">
+        <div class="row g-4 g-xl-5">
+          <aside class="col-lg-3 col-xl-2">
+            <nav class="docs-sidenav" aria-label="Documentation navigation">
+              {nav.map(item => {
+                const itemPath = normalize(item.url);
+                const isActive = currentPath.startsWith(itemPath);
+                return (
+                  <a
+                    href={item.url}
+                    class={`docs-sidenav__link${isActive ? ' active' : ''}`}
+                    style={`--nav-depth: ${item.depth}`}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {item.title}
+                  </a>
+                );
+              })}
             </nav>
           </aside>
-          <div class="col-md-9">
-            <slot />
+          <div class="col-lg-9 col-xl-10">
+            <article class="docs-content">
+              <slot />
+            </article>
           </div>
         </div>
       </div>

--- a/src/pages/lab/index.astro
+++ b/src/pages/lab/index.astro
@@ -6,50 +6,91 @@ const nav = getLabNav();
 ---
 
 <DocsLayout title="Lab & Cultivation" description="Guides and protocols for mushroom cultivation" nav={nav}>
-  <div class="container my-5">
-    <h1 class="mb-4 text-center">Lab & Cultivation</h1>
-    <p class="lead text-center">Guides, teks, and protocols for successful mushroom cultivation.</p>
-    <div class="row row-cols-1 row-cols-md-2 g-4 mt-4">
+  <section class="docs-landing">
+    <header class="text-center mb-5">
+      <h1 class="mb-3">Lab &amp; Cultivation</h1>
+      <p class="lead text-muted">Guides, teks, and protocols for successful mushroom cultivation.</p>
+    </header>
+    <div class="row row-cols-1 row-cols-md-2 g-4">
       <div class="col">
-        <a href="/lab/cultivation/beginner/pf-tek" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Cultivation Basics</h5>
-              <p class="card-text">Step-by-step PF-Tek and other beginner teks.</p>
-            </div>
+        <a
+          href="/lab/cultivation/beginner/pf-tek"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Cultivation Basics</h5>
+            <p class="card-text text-muted">Step-by-step PF-Tek and other beginner teks.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/lab/cultivation/beginner/grain-prep" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Preparing Grain Spawn</h5>
-              <p class="card-text">Rinsing, soaking, and sterilizing grain for inoculation.</p>
-            </div>
+        <a
+          href="/lab/cultivation/beginner/grain-prep"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Preparing Grain Spawn</h5>
+            <p class="card-text text-muted">Rinsing, soaking, and sterilizing grain for inoculation.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/lab/lab/intro" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Lab Techniques</h5>
-              <p class="card-text">Agar cloning, liquid culture, and sterile technique.</p>
-            </div>
+        <a href="/lab/lab/intro" class="docs-card card h-100 shadow-sm text-decoration-none">
+          <div class="card-body">
+            <h5 class="card-title">Lab Techniques</h5>
+            <p class="card-text text-muted">Agar cloning, liquid culture, and sterile technique.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/lab/lab/agar-basics" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Agar Basics</h5>
-              <p class="card-text">Recipes and tips for pouring clean agar plates.</p>
-            </div>
+        <a href="/lab/lab/agar-basics" class="docs-card card h-100 shadow-sm text-decoration-none">
+          <div class="card-body">
+            <h5 class="card-title">Agar Basics</h5>
+            <p class="card-text text-muted">Recipes and tips for pouring clean agar plates.</p>
           </div>
         </a>
       </div>
     </div>
-  </div>
+    <section class="docs-plan card shadow-sm mt-5">
+      <div class="card-body">
+        <h2 class="h4 text-uppercase mb-3">Lab documentation roadmap</h2>
+        <p class="text-muted mb-4">
+          A working outline that groups upcoming lab guides into progressive modules so growers can
+          build confidence in a logical order.
+        </p>
+        <div class="row g-4">
+          <div class="col-md-4">
+            <div class="docs-plan__module">
+              <h3 class="h6 text-uppercase">Foundation</h3>
+              <ul class="docs-plan__list">
+                <li>Workspace setup &amp; sanitation checklist</li>
+                <li>Essential tools and consumables inventory</li>
+                <li>Sterile workflow fundamentals</li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="docs-plan__module">
+              <h3 class="h6 text-uppercase">Cultivation cycles</h3>
+              <ul class="docs-plan__list">
+                <li>Spawn production quality benchmarks</li>
+                <li>Bulk substrate preparation &amp; bag workflows</li>
+                <li>Fruiting chamber management playbooks</li>
+              </ul>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="docs-plan__module">
+              <h3 class="h6 text-uppercase">Optimization &amp; QA</h3>
+              <ul class="docs-plan__list">
+                <li>Contamination diagnostics and response trees</li>
+                <li>Data logging templates for experiments</li>
+                <li>Scaling considerations for small labs</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </section>
 </DocsLayout>

--- a/src/pages/mycopedia/index.astro
+++ b/src/pages/mycopedia/index.astro
@@ -6,67 +6,75 @@ const nav = getDocsNav();
 ---
 
 <DocsLayout title="MycoPedia" description="Documentation and guides for MycoSci" nav={nav}>
-  <div class="container my-5">
-    <h1 class="mb-4 text-center">MycoPedia</h1>
-    <p class="lead text-center">Your free, community-powered field guide to the fungal kingdom.</p>
-    <div class="row row-cols-1 row-cols-md-2 g-4 mt-4">
+  <section class="docs-landing">
+    <header class="text-center mb-5">
+      <h1 class="mb-3">MycoPedia</h1>
+      <p class="lead text-muted">Your free, community-powered field guide to the fungal kingdom.</p>
+    </header>
+    <div class="row row-cols-1 row-cols-md-2 g-4">
       <div class="col">
-        <a href="/mycopedia/Taxonomy/" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Field Guide</h5>
-              <p class="card-text">Browse taxonomy from phylum down to individual species.</p>
-            </div>
+        <a
+          href="/mycopedia/Taxonomy/"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Field Guide</h5>
+            <p class="card-text text-muted">Browse taxonomy from phylum down to individual species.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/mycopedia/cultivation/beginner/pf-tek" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Cultivation Basics</h5>
-              <p class="card-text">Step-by-step monotub, PF-tek, and gourmet log methods.</p>
-            </div>
+        <a
+          href="/mycopedia/cultivation/beginner/pf-tek"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Cultivation Basics</h5>
+            <p class="card-text text-muted">Step-by-step monotub, PF-tek, and gourmet log methods.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/mycopedia/lab/intro" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Lab Techniques</h5>
-              <p class="card-text">Agar cloning, liquid culture, and sterile technique.</p>
-            </div>
+        <a
+          href="/mycopedia/lab/intro"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Lab Techniques</h5>
+            <p class="card-text text-muted">Agar cloning, liquid culture, and sterile technique.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/mycopedia/recipes/intro" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Recipes</h5>
-              <p class="card-text">Culinary ideas for cooking wild and cultivated fungi.</p>
-            </div>
+        <a
+          href="/mycopedia/recipes/intro"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Recipes</h5>
+            <p class="card-text text-muted">Culinary ideas for cooking wild and cultivated fungi.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/mycopedia/chemistry-nutrition/mushroom-nutrition" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Nutrition & Chemistry</h5>
-              <p class="card-text">Explore medicinal compounds and health benefits.</p>
-            </div>
+        <a
+          href="/mycopedia/chemistry-nutrition/mushroom-nutrition"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Nutrition &amp; Chemistry</h5>
+            <p class="card-text text-muted">Explore medicinal compounds and health benefits.</p>
           </div>
         </a>
       </div>
       <div class="col">
-        <a href="/mycopedia/references/historical-literature" class="text-decoration-none">
-          <div class="card h-100 bg-dark text-white">
-            <div class="card-body">
-              <h5 class="card-title">Research Library</h5>
-              <p class="card-text">Curated papers, genome data sets, and historic texts.</p>
-            </div>
+        <a
+          href="/mycopedia/references/historical-literature"
+          class="docs-card card h-100 shadow-sm text-decoration-none"
+        >
+          <div class="card-body">
+            <h5 class="card-title">Research Library</h5>
+            <p class="card-text text-muted">Curated papers, genome data sets, and historic texts.</p>
           </div>
         </a>
       </div>
@@ -74,5 +82,5 @@ const nav = getDocsNav();
     <div class="text-center mt-5">
       <a href="/mycopedia/quick-start" class="btn btn-primary btn-lg">Quick Start Guide</a>
     </div>
-  </div>
+  </section>
 </DocsLayout>


### PR DESCRIPTION
## Summary
- simplify the global header to a clean light navbar with active link highlighting
- rework the shared docs layout to use the light site theme with a sticky sidenav and card-style content well
- refresh the MycoPedia and Lab landing pages with light cards and add a lab documentation roadmap section, with supporting CSS utilities

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ca4139ec908323b8f1f4d3ba6a7118