### PR TITLE
Adjust docs sidebar layout and remove body accent

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -32,21 +32,7 @@
 }
 
 .nasa-body::before {
-  background: linear-gradient(
-    180deg,
-    var(--nasa-blue) 0%,
-    var(--nasa-blue) 52%,
-    var(--nasa-red) 52%,
-    var(--nasa-red) 100%
-  );
-  content: "";
-  height: 100vh;
-  left: 0;
-  position: fixed;
-  top: 0;
-  width: 12px;
-  pointer-events: none;
-  z-index: 0;
+  content: none;
 }
 
 .nasa-body::selection {

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -33,7 +33,7 @@ const currentPath = normalize(Astro.url.pathname);
     <main class="flex-fill py-5">
       <div class="container">
         <div class="row g-4 g-xl-5">
-          <aside class="col-lg-3 col-xl-2">
+          <aside class="col-lg-4 col-xl-3">
             <nav class="docs-sidenav" aria-label="Documentation navigation">
               {nav.map(item => {
                 const itemPath = normalize(item.url);
@@ -51,7 +51,7 @@ const currentPath = normalize(Astro.url.pathname);
               })}
             </nav>
           </aside>
-          <div class="col-lg-9 col-xl-10">
+          <div class="col-lg-8 col-xl-9">
             <article class="docs-content">
               <slot />
             </article>


### PR DESCRIPTION
## Summary
- widen the docs layout so the sidebar column has more room on large viewports
- disable the pseudo-element that drew the blue/orange accent on the left edge of the page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca46b5ac7083239e7e949a9d347934