### PR TITLE
Adopt Starlight-style shell for site

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -23,7 +23,10 @@
     100% 64px,
     64px 100%;
   color: var(--nasa-ink);
+  display: flex;
+  flex-direction: column;
   font-family: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+  min-height: 100vh;
   letter-spacing: 0.01em;
   line-height: 1.6;
   position: relative;
@@ -38,6 +41,363 @@
 .nasa-body::selection {
   background-color: var(--nasa-blue);
   color: #fff;
+}
+
+.skip-link {
+  background: var(--nasa-blue);
+  border-radius: 0 0 4px 4px;
+  color: #fff;
+  font-family: "IBM Plex Mono", "IBM Plex Sans", sans-serif;
+  font-size: 0.875rem;
+  letter-spacing: 0.14em;
+  padding: 0.5rem 1rem;
+  position: absolute;
+  left: 1rem;
+  top: 0;
+  transform: translateY(-150%);
+  transition: transform 0.2s ease;
+  z-index: 200;
+}
+
+.skip-link:focus {
+  outline: none;
+  transform: translateY(0%);
+}
+
+.sl-container {
+  margin: 0 auto;
+  max-width: 1180px;
+  padding-inline: clamp(1rem, 4vw, 2.75rem);
+  width: 100%;
+}
+
+.sl-main {
+  flex: 1 0 auto;
+  padding-block: clamp(2.5rem, 4vw, 4rem);
+}
+
+.sl-main--docs {
+  padding-block: clamp(2rem, 3vw, 3.5rem);
+}
+
+.sl-header {
+  background: linear-gradient(
+    180deg,
+    rgba(16, 26, 50, 0.95),
+    rgba(16, 26, 50, 0.88)
+  );
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 30px rgba(12, 32, 74, 0.24);
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 120;
+}
+
+.sl-header__band {
+  background: linear-gradient(90deg, var(--nasa-red), var(--nasa-blue));
+  height: 3px;
+  width: 100%;
+}
+
+.sl-header__inner {
+  align-items: center;
+  display: flex;
+  gap: 1.5rem;
+  justify-content: space-between;
+  padding-block: 1rem;
+}
+
+.sl-header__brand {
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  font-family: "Barlow Condensed", "Helvetica Neue", Arial, sans-serif;
+  gap: 0.15rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.sl-header__brand:hover,
+.sl-header__brand:focus {
+  color: #fff;
+  text-decoration: none;
+}
+
+.sl-header__wordmark {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  letter-spacing: 0.32em;
+}
+
+.sl-header__tagline {
+  color: rgba(255, 255, 255, 0.7);
+  font-family: "IBM Plex Mono", "IBM Plex Sans", sans-serif;
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+}
+
+.sl-header__toggle {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  color: #fff;
+  display: none;
+  font-family: "IBM Plex Mono", "IBM Plex Sans", sans-serif;
+  font-size: 0.75rem;
+  gap: 0.5rem;
+  letter-spacing: 0.24em;
+  padding: 0.5rem 1rem;
+  text-transform: uppercase;
+}
+
+.sl-header__toggle:focus-visible {
+  outline: 2px solid var(--nasa-red);
+  outline-offset: 3px;
+}
+
+.sl-header__nav {
+  display: block;
+}
+
+.sl-header__nav.is-open {
+  display: block;
+}
+
+.sl-header__list {
+  align-items: center;
+  display: flex;
+  gap: clamp(1rem, 3vw, 2rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sl-header__item {
+  margin: 0;
+}
+
+.sl-header__link {
+  color: rgba(255, 255, 255, 0.75);
+  font-family: "IBM Plex Mono", "IBM Plex Sans", sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  position: relative;
+  text-transform: uppercase;
+  transition: color 0.15s ease;
+}
+
+.sl-header__link::after {
+  background: rgba(255, 255, 255, 0.65);
+  border-radius: 999px;
+  bottom: -0.75rem;
+  content: "";
+  height: 2px;
+  left: 0;
+  opacity: 0;
+  position: absolute;
+  transform: scaleX(0.4);
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+  width: 100%;
+}
+
+.sl-header__link:hover,
+.sl-header__link:focus {
+  color: #fff;
+}
+
+.sl-header__link.is-active {
+  color: #fff;
+}
+
+.sl-header__link.is-active::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.sl-main .sl-container {
+  position: relative;
+}
+
+.sl-docs {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 3rem);
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+}
+
+.sl-docs__sidebar {
+  align-self: start;
+  position: sticky;
+  top: 5.75rem;
+}
+
+.sl-docs__nav {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid var(--nasa-border);
+  border-radius: 14px;
+  box-shadow: 0 14px 30px rgba(11, 61, 145, 0.12);
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  position: relative;
+}
+
+.sl-docs__link {
+  border-left: 3px solid transparent;
+  color: var(--nasa-slate);
+  display: block;
+  font-family: "IBM Plex Sans", Arial, sans-serif;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  margin-left: calc(var(--nav-depth) * 0.75rem);
+  padding: 0.35rem 0.65rem;
+  text-transform: uppercase;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.sl-docs__link:hover,
+.sl-docs__link:focus {
+  background: rgba(11, 61, 145, 0.08);
+  border-color: var(--nasa-blue);
+  color: var(--nasa-blue);
+}
+
+.sl-docs__link.is-active {
+  background: rgba(11, 61, 145, 0.12);
+  border-color: var(--nasa-blue);
+  color: var(--nasa-blue);
+  font-weight: 600;
+}
+
+.sl-docs__content {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(11, 61, 145, 0.12);
+  border-radius: 18px;
+  box-shadow: 0 24px 45px rgba(12, 32, 74, 0.18);
+  padding: clamp(1.75rem, 3vw, 3rem);
+}
+
+.sl-footer {
+  background: rgba(16, 26, 50, 0.96);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.78);
+  padding-block: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.sl-footer__band {
+  background: linear-gradient(90deg, var(--nasa-blue), var(--nasa-red));
+  height: 3px;
+  margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.sl-footer__inner {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.sl-footer__brand {
+  color: #fff;
+  font-family: "Barlow Condensed", "Helvetica Neue", Arial, sans-serif;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  letter-spacing: 0.32em;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+
+.sl-footer__about {
+  max-width: 360px;
+}
+
+.sl-footer__copy {
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.05em;
+}
+
+.sl-footer__links {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.sl-footer__title {
+  color: rgba(255, 255, 255, 0.6);
+  font-family: "IBM Plex Mono", "IBM Plex Sans", sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.sl-footer__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sl-footer__link {
+  color: rgba(255, 255, 255, 0.78);
+  display: inline-flex;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  padding-block: 0.35rem;
+  text-transform: uppercase;
+}
+
+.sl-footer__link:hover,
+.sl-footer__link:focus {
+  color: #fff;
+}
+
+.sl-footer__meta {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin-top: clamp(1rem, 3vw, 2rem);
+  padding-top: clamp(1rem, 2vw, 1.5rem);
+  text-align: center;
+}
+
+@media (max-width: 960px) {
+  .sl-header__toggle {
+    display: inline-flex;
+  }
+
+  .sl-header__nav {
+    background: rgba(16, 26, 50, 0.96);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    box-shadow: 0 18px 40px rgba(5, 14, 36, 0.35);
+    display: none;
+    left: clamp(1rem, 4vw, 2.5rem);
+    padding: 1.5rem;
+    position: absolute;
+    right: clamp(1rem, 4vw, 2.5rem);
+    top: calc(100% + 0.75rem);
+  }
+
+  .sl-header__nav.is-open {
+    display: block;
+  }
+
+  .sl-header__list {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .sl-docs {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sl-docs__sidebar {
+    position: static;
+  }
+
+  .sl-docs__nav {
+    position: relative;
+  }
 }
 
 a {
@@ -293,7 +653,8 @@ li {
   font-weight: 600;
 }
 
-.docs-content {
+.docs-content,
+.sl-docs__content {
   background: #fff;
   border: 1px solid var(--nasa-border);
   border-radius: 0.75rem;
@@ -301,11 +662,13 @@ li {
   padding: clamp(1.75rem, 2vw + 1.25rem, 3rem);
 }
 
-.docs-content > :first-child {
+.docs-content > :first-child,
+.sl-docs__content > :first-child {
   margin-top: 0;
 }
 
-.docs-content > :last-child {
+.docs-content > :last-child,
+.sl-docs__content > :last-child {
   margin-bottom: 0;
 }
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,43 +1,42 @@
 ---
 ---
-<footer class="nasa-footer mt-auto">
-  <div class="nasa-footer__band"></div>
-  <div class="container py-5">
-    <div class="row g-4 align-items-start">
-      <div class="col-12 col-lg-5">
-        <h5 class="nasa-footer__brand text-uppercase">MycoSci</h5>
-        <p class="nasa-footer__copy mb-0">
-          Mapping fungal frontiers with the mission precision of classic aerospace.
-        </p>
-      </div>
-      <div class="col-6 col-lg-3">
-        <h6 class="nasa-footer__title">Discover</h6>
-        <ul class="list-unstyled nasa-footer__list mb-0">
-          <li><a href="/gallery" class="nasa-footer__link">Gallery</a></li>
-          <li><a href="/mycopedia" class="nasa-footer__link">MycoPedia</a></li>
-          <li><a href="/lab" class="nasa-footer__link">Lab &amp; Cultivation</a></li>
+<footer class="sl-footer">
+  <div class="sl-footer__band" aria-hidden="true"></div>
+  <div class="sl-container sl-footer__inner">
+    <div class="sl-footer__about">
+      <h5 class="sl-footer__brand">MycoSci</h5>
+      <p class="sl-footer__copy">
+        Mapping fungal frontiers with the mission precision of classic aerospace.
+      </p>
+    </div>
+    <div class="sl-footer__links">
+      <div>
+        <h6 class="sl-footer__title">Discover</h6>
+        <ul class="sl-footer__list">
+          <li><a href="/gallery" class="sl-footer__link">Gallery</a></li>
+          <li><a href="/mycopedia" class="sl-footer__link">MycoPedia</a></li>
+          <li><a href="/lab" class="sl-footer__link">Lab &amp; Cultivation</a></li>
         </ul>
       </div>
-      <div class="col-6 col-lg-2">
-        <h6 class="nasa-footer__title">Learn</h6>
-        <ul class="list-unstyled nasa-footer__list mb-0">
-          <li><a href="/blog" class="nasa-footer__link">Blog</a></li>
-          <li><a href="/resources" class="nasa-footer__link">Resources</a></li>
-          <li><a href="/mycopedia/quick-start" class="nasa-footer__link">Quick Start Guide</a></li>
+      <div>
+        <h6 class="sl-footer__title">Learn</h6>
+        <ul class="sl-footer__list">
+          <li><a href="/blog" class="sl-footer__link">Blog</a></li>
+          <li><a href="/resources" class="sl-footer__link">Resources</a></li>
+          <li><a href="/mycopedia/quick-start" class="sl-footer__link">Quick Start Guide</a></li>
         </ul>
       </div>
-      <div class="col-6 col-lg-2">
-        <h6 class="nasa-footer__title">Mission</h6>
-        <ul class="list-unstyled nasa-footer__list mb-0">
-          <li><a href="/" class="nasa-footer__link">Home</a></li>
-          <li><a href="/mycopedia" class="nasa-footer__link">Reference</a></li>
-          <li><a href="#top" class="nasa-footer__link">Back to Top</a></li>
+      <div>
+        <h6 class="sl-footer__title">Mission</h6>
+        <ul class="sl-footer__list">
+          <li><a href="/" class="sl-footer__link">Home</a></li>
+          <li><a href="/mycopedia" class="sl-footer__link">Reference</a></li>
+          <li><a href="#top" class="sl-footer__link">Back to Top</a></li>
         </ul>
       </div>
     </div>
-    <div class="nasa-footer__divider mt-5"></div>
-    <div class="text-center pt-4">
-      <small class="nasa-footer__copy">&copy; {new Date().getFullYear()} MycoSci</small>
+    <div class="sl-footer__meta">
+      <small class="sl-footer__copy">&copy; {new Date().getFullYear()} MycoSci</small>
     </div>
   </div>
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,62 +1,70 @@
 ---
 const navLinks = [
-  { href: '/gallery', label: 'Gallery' },
+  { href: '/', label: 'Home' },
   { href: '/mycopedia', label: 'MycoPedia' },
-  { href: '/blog', label: 'Blog' },
+  { href: '/gallery', label: 'Gallery' },
   { href: '/lab', label: 'Lab & Cultivation' },
+  { href: '/resources', label: 'Resources' },
+  { href: '/blog', label: 'Blog' },
 ];
 
 const normalize = (value: string) => (value.endsWith('/') ? value : value + '/');
 const currentPath = normalize(Astro.url.pathname);
 const isActive = (href: string) => currentPath.startsWith(normalize(href));
+const navId = 'primary-navigation';
 ---
-<header class="site-header">
-  <nav class="navbar navbar-expand-lg site-navbar" aria-label="Primary navigation">
-    <div class="container">
-      <a class="navbar-brand site-navbar__brand" href="/">
-        <span class="site-navbar__wordmark">MycoSci</span>
-        <span class="site-navbar__sub">Mycology Systems Division</span>
-      </a>
-      <button
-        class="navbar-toggler"
-        type="button"
-        data-bs-toggle="collapse"
-        data-bs-target="#navbarNav"
-        aria-controls="navbarNav"
-        aria-expanded="false"
-        aria-label="Toggle navigation"
-      >
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          {navLinks.map(link => {
-            const active = isActive(link.href);
-            return (
-              <li class="nav-item">
-                <a
-                  class={`nav-link${active ? ' active' : ''}`}
-                  href={link.href}
-                  aria-current={active ? 'page' : undefined}
-                >
-                  {link.label}
-                </a>
-              </li>
-            );
-          })}
-        </ul>
-        <form class="d-none d-lg-flex" role="search">
-          <label class="visually-hidden" for="header-search">Search the catalog</label>
-          <input
-            id="header-search"
-            class="form-control form-control-sm me-2"
-            type="search"
-            placeholder="Species, labs, posts"
-            aria-label="Search"
-          />
-          <button class="btn btn-outline-primary btn-sm" type="submit">Search</button>
-        </form>
-      </div>
-    </div>
-  </nav>
+<header class="sl-header" data-sl-header>
+  <div class="sl-header__band" aria-hidden="true"></div>
+  <div class="sl-container sl-header__inner">
+    <a class="sl-header__brand" href="/">
+      <span class="sl-header__wordmark">MycoSci</span>
+      <span class="sl-header__tagline">Mycology Systems Division</span>
+    </a>
+    <button
+      class="sl-header__toggle"
+      type="button"
+      aria-expanded="false"
+      aria-controls={navId}
+      data-sl-nav-toggle
+    >
+      Menu
+    </button>
+    <nav id={navId} class="sl-header__nav" aria-label="Primary navigation" data-sl-nav>
+      <ul class="sl-header__list">
+        {navLinks.map(link => {
+          const active = isActive(link.href);
+          return (
+            <li class="sl-header__item">
+              <a
+                class={`sl-header__link${active ? ' is-active' : ''}`}
+                href={link.href}
+                aria-current={active ? 'page' : undefined}
+              >
+                {link.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  </div>
+  <script is:inline>
+    const headers = document.querySelectorAll('[data-sl-header]');
+    headers.forEach(header => {
+      const toggle = header.querySelector('[data-sl-nav-toggle]');
+      const nav = header.querySelector('[data-sl-nav]');
+      if (!toggle || !nav) return;
+      toggle.addEventListener('click', () => {
+        const isOpen = nav.classList.toggle('is-open');
+        toggle.setAttribute('aria-expanded', String(isOpen));
+      });
+      nav.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+          nav.classList.remove('is-open');
+          toggle.setAttribute('aria-expanded', 'false');
+          toggle.focus();
+        }
+      });
+    });
+  </script>
 </header>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -28,42 +28,34 @@ const currentPath = normalize(Astro.url.pathname);
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body id="top" class="nasa-body d-flex flex-column min-vh-100">
+  <body id="top" class="nasa-body">
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <Header />
-    <main class="flex-fill py-5">
-      <div class="container">
-        <div class="row g-4 g-xl-5">
-          <aside class="col-lg-4 col-xl-3">
-            <nav class="docs-sidenav" aria-label="Documentation navigation">
-              {nav.map(item => {
-                const itemPath = normalize(item.url);
-                const isActive = currentPath.startsWith(itemPath);
-                return (
-                  <a
-                    href={item.url}
-                    class={`docs-sidenav__link${isActive ? ' active' : ''}`}
-                    style={`--nav-depth: ${item.depth}`}
-                    aria-current={isActive ? 'page' : undefined}
-                  >
-                    {item.title}
-                  </a>
-                );
-              })}
-            </nav>
-          </aside>
-          <div class="col-lg-8 col-xl-9">
-            <article class="docs-content">
-              <slot />
-            </article>
-          </div>
-        </div>
+    <main id="main-content" class="sl-main sl-main--docs" role="main">
+      <div class="sl-docs">
+        <aside class="sl-docs__sidebar" aria-label="Documentation navigation">
+          <nav class="sl-docs__nav">
+            {nav.map(item => {
+              const itemPath = normalize(item.url);
+              const isActive = currentPath.startsWith(itemPath);
+              return (
+                <a
+                  href={item.url}
+                  class={`sl-docs__link${isActive ? ' is-active' : ''}`}
+                  style={`--nav-depth: ${item.depth}`}
+                  aria-current={isActive ? 'page' : undefined}
+                >
+                  {item.title}
+                </a>
+              );
+            })}
+          </nav>
+        </aside>
+        <article class="sl-docs__content">
+          <slot />
+        </article>
       </div>
     </main>
     <Footer />
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -27,18 +27,14 @@ import Footer from '../components/Footer.astro';
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="stylesheet" href="/styles.css" />
   </head>
-  <body id="top" class="nasa-body d-flex flex-column min-vh-100">
+  <body id="top" class="nasa-body">
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <Header />
-    <main class="flex-fill py-4">
-      <div class="container">
+    <main id="main-content" class="sl-main" role="main">
+      <div class="sl-container">
         <slot />
       </div>
     </main>
     <Footer />
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the site and docs layouts with a unified Starlight-inspired frame that keeps existing content routes
- refresh the header and footer with responsive navigation and mission-themed styling
- expand the shared stylesheet with new body, navigation, docs, and footer treatments to match the updated frame

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca523f946c8323972e1704a987a224