### PR TITLE
Fix Starlight config import usage

### DIFF
--- a/starlight.config.mjs
+++ b/starlight.config.mjs
@@ -1,6 +1,7 @@
-import { defineConfig } from "@astrojs/starlight/config";
-
-export default defineConfig({
+/**
+ * @type {import('@astrojs/starlight').StarlightConfig}
+ */
+export default {
   title: "MycoPedia",
   description:
     "MycoSci field guides, lab protocols, and reference documentation.",
@@ -85,4 +86,4 @@ export default defineConfig({
       autogenerate: { directory: "Reference" },
     },
   ],
-});
+};


### PR DESCRIPTION
## Summary
- export the Starlight configuration object directly instead of importing the helper that triggered a missing specifier error

## Testing
- npm run build *(fails locally: Cannot find module '@astrojs/starlight' because the package cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3d1e8a148323b9e0b82424eef28b