### PR TITLE
fix: reorder astro integrations

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,12 +4,17 @@ import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import starlightConfig from "./starlight.config.mjs";
 
-const integrations = [mdx()];
+const integrations = [];
 const alias = {};
 
 try {
   const { default: starlight } = await import("@astrojs/starlight");
-  integrations.push(starlight(starlightConfig));
+  const starlightIntegration = starlight(starlightConfig);
+  if (Array.isArray(starlightIntegration)) {
+    integrations.push(...starlightIntegration);
+  } else if (starlightIntegration) {
+    integrations.push(starlightIntegration);
+  }
 } catch (error) {
   if (
     error &&
@@ -26,6 +31,8 @@ try {
     new URL("./src/components/starlight/index.ts", import.meta.url),
   );
 }
+
+integrations.push(mdx());
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
## Summary
- ensure Starlight-provided integrations are registered before MDX so astro-expressive-code loads in the expected order

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb878663f88323a193e042a339fc31