### PR TITLE
fix: resolve starlight favicon path

### DIFF
--- a/starlight.config.mjs
+++ b/starlight.config.mjs
@@ -1,3 +1,9 @@
+import { fileURLToPath } from "node:url";
+
+const faviconPath = fileURLToPath(
+  new URL("./public/favicon.svg", import.meta.url),
+);
+
 /**
  * @type {import('@astrojs/starlight').StarlightConfig}
  */
@@ -6,8 +12,8 @@ export default {
   description:
     "MycoSci field guides, lab protocols, and reference documentation.",
   logo: {
-    light: "/favicon.svg",
-    dark: "/favicon.svg",
+    light: faviconPath,
+    dark: faviconPath,
   },
   social: {
     github: "https://github.com/MycoSci/mycosci.github.io",


### PR DESCRIPTION
## Summary
- resolve the Starlight logo configuration to the favicon on disk so builds can find the image

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb89ee5628832380fd9b73e2cd3b47