### PR TITLE
docs: add foraging faq from legacy site

### DIFF
--- a/src/content/docs/Guides/Ganoderma-lucidum.mdx
+++ b/src/content/docs/Guides/Ganoderma-lucidum.mdx
@@ -1,0 +1,236 @@
+---
+title: "Reishi / Lingzhi (Ganoderma lucidum)"
+description: "Comprehensive species profile for the reishi mushroom, covering wild and cultivated forms, molecular genetics, traditional uses, and more."
+---
+
+import {
+  Card,
+  CardGrid,
+  Badge,
+  Aside,
+  Steps,
+  Tabs,
+  TabItem,
+  Icon,
+  LinkButton,
+} from "@astrojs/starlight/components";
+
+# _Ganoderma lucidum_
+
+{/* prettier-ignore-start */}
+
+<CardGrid stagger>
+  <Card title="Quick Facts" icon="sparkles">
+    - <Badge text="inedible" />- **Cap**: Shiny, varnished reddish-brown,
+    kidney-shaped, 5–15 cm - **Gills / Ridges / Pores**: White to cream pore
+    surface (~4–5 pores/mm) - **Spore Print**: Brown
+  </Card>
+  <Card title="Habitat Snapshot" icon="map">
+    - **Substrate**: Decaying hardwood (oak, maple, etc.) - **Habitat**:
+    Temperate forest floors, stumps, buried roots - **Range**: Native Europe;
+    introduced/cultivated in Asia & N. America - **Season**: Summer to early
+    autumn
+  </Card>
+</CardGrid>
+{/* prettier-ignore-end */}
+
+<Aside type="caution" title="Safety Note">
+  Non-toxic but very bitter and woody—used as medicine, not food. Possible mild
+  side effects: dry mouth, stomach upset, rash; bleeding risk if on
+  anticoagulants; rare liver toxicity with prolonged high-dose powder use.
+</Aside>
+
+## 1. Scientific Taxonomy
+
+| Rank              | Name                                                                 |
+| ----------------- | -------------------------------------------------------------------- |
+| Kingdom           | Fungi                                                                |
+| Division / Phylum | Basidiomycota                                                        |
+| Class             | Agaricomycetes                                                       |
+| Order             | Polyporales                                                          |
+| Family            | Ganodermataceae                                                      |
+| Genus             | _Ganoderma_                                                          |
+| Species           | _lucidum_                                                            |
+| Authority         | (Curtis) P. Karst. (1881)                                            |
+| Synonyms          | _Boletus lucidus_ Curtis 1781 <br></br> _Polyporus lucidus_ Fr. 1821 |
+
+## 2. Discovery & Naming
+
+The species _Ganoderma lucidum_ was first described in Western science by English botanist William Curtis in 1781 as *Boletus lucidus*​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=The%20history%20of%20the%20Ganoderma,6). It was later reclassified by Elias Fries in 1821 as _Polyporus lucidus_, before Finnish mycologist Petter Adolf Karsten established the genus _Ganoderma_ in 1881 with _G. lucidum_ (Curtis) P. Karst. as the type species​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=The%20history%20of%20the%20Ganoderma,6). The genus name _Ganoderma_ derives from Greek _ganos_ (brightness, sheen) and _derma_ (skin), and the species epithet _lucidum_ comes from Latin _lucidus_ meaning "shining" or "brilliant" -- referring to the varnished appearance of the fruiting body​[ncbi.nlm.nih.gov](https://www.ncbi.nlm.nih.gov/books/NBK92757/#:~:text=Ganoderma%20lucidum%2C%20an%20oriental%20fungus,family%20is%20reishi%20or%20mannentake)​[ncbi.nlm.nih.gov](https://www.ncbi.nlm.nih.gov/books/NBK92757/#:~:text=The%20proliferation%20of%20G,holy%20farmer%E2%80%9D%3B%20%2023%20Zhu).
+
+Historically, _G. lucidum_ has a long record of use in East Asia, being revered in China, Japan, and Korea for over two millennia​[ncbi.nlm.nih.gov](https://www.ncbi.nlm.nih.gov/books/NBK92757/#:~:text=Lingzhi%20has%20been%20recognized%20as,and%20was%20composed%20in%20the). It appears in the oldest Chinese herbal texts such as the _Shen Nong Ben Cao Jing_ (Eastern Han dynasty, ~1st--2nd century AD) and was classified as a superior herbal medicine believed to promote longevity​[ncbi.nlm.nih.gov](https://www.ncbi.nlm.nih.gov/books/NBK92757/#:~:text=women%E2%80%99s%20accessories%20%28Wasser%202005%20%29,536%20AD%29%20and%20the%20Ben)​[nissankenko.com](https://www.nissankenko.com/eng/about/#:~:text=considered%20supreme%20as%20a%20good,mushroom%20variety%20that%20promoted%20health). In Japan, it was documented in the _Nihon Shoki_ (720 AD) and known as "Mannentake" (10,000-year mushroom), indicating its perceived health benefits and rarity​[nissankenko.com](https://www.nissankenko.com/eng/about/#:~:text=reishi%20is%20allocated%20to%20the,mushroom%20variety%20that%20promoted%20health). Culturally, the mushroom was so rare in the wild that it was historically reserved for royalty and nobility; legends claimed it grew in the abodes of immortals, contributing to its aura as an elixir of immortality​[ncbi.nlm.nih.gov](https://www.ncbi.nlm.nih.gov/books/NBK92757/#:~:text=Wild%20lingzhi%20is%20rare%2C%20and,Lindequist%2C%20Niedermeyer%2C%20and%20J%C3%BClich%202005).
+
+**Taxonomic Confusion:** The name _Ganoderma lucidum_ has been applied broadly to many similar "reishi" mushrooms around the world, causing significant confusion in mycology​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=Despite%20this%20recognition%20of%20additional,same%20clade%3A%20based%20on%20molecular). Modern taxonomy recognizes that the true _G. lucidum_ (sensu stricto), originally from Europe, is distinct from the Asian species used in traditional medicine​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=and%20the%20species%20name%20Ganoderma,1). Notably, the famed red reishi of China and Japan is now identified as _Ganoderma lingzhi_ (synonym _G. sichuanense_), which is **not** a synonym of _G. lucidum_ and belongs to a different genetic clade​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=and%20the%20species%20name%20Ganoderma,1). Phylogenetic studies show _G. lucidum_ is more closely related to North American species like _G. tsugae_ (hemlock reishi) and _G. oregonense_ than to *G. lingzhi*​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=%28China%29%29%2C%20the%20sought,1). For example, a 2015 molecular phylogeny identified three major lineages of Ganoderma globally, separating the European _G. lucidum_ lineage from the Asian _G. lingzhi_ lineage and others​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=A%202015%20phylogeny%20study%20revealed,11). This clarification means that many commercial "_G. lucidum_" products, especially those cultivated in Asia, are actually *G. lingzhi*​[en.wikipedia.org](https://en.wikipedia.org/wiki/Ganoderma_lucidum#:~:text=and%20the%20species%20name%20Ganoderma,Ganoderma%20oregonense%20than%20to%20G). Nonetheless, the historical name "_Ganoderma lucidum_" continues to be used in literature and commerce as an umbrella term for the **Reishi/Lingzhi** mushrooms.
+
+- **Discoverer / Describer:** William Curtis
+- **Year Described:** 1781 (as _Boletus lucidus_)
+- **Type Locality:** Britain (original Curtis herbarium specimen)
+- **Type Specimen ID:** Curtis collection (exact ID uncertain)
+- **Etymology:** Greek _ganos_ (“brightness”) + _derma_ (“skin”); Latin _lucidus_ (“shining”), referring to the varnished cap.
+- **Historical Notes:** First placed in _Boletus_, then _Polyporus_ (Fries 1821), and finally _Ganoderma_ (Karsten 1881). Revered in China’s _Shen Nong Ben Cao Jing_ (~1st c. AD) and Japan’s _Nihon Shoki_ (720 AD) as a longevity elixir.
+
+## 3. Morphological Characteristics
+
+{/* prettier-ignore-start */}
+
+<Tabs syncKey="morphology">
+  <TabItem label="Macroscopic" icon="eye">
+
+    ### Cap
+
+    - **Shape:** Kidney- to fan-shaped
+    - **Size:** 5 – 15 cm diameter
+    - **Color:** Reddish-brown with whitish margin
+    - **Surface:** Hard, woody, varnished gloss
+
+    ### Gills / Ridges / Pores
+
+    - **Type:** Tiny circular pores (~4–5/mm)
+    - **Attachment:** Decurrent (runs down stem)
+    - **Color:** White to cream
+
+    ### Stem
+
+    - **Present:** Yes, lateral
+    - **Dimensions:** 3 – 10 cm × 1 – 3 cm
+    - **Characteristics:** Glossy reddish-brown, cylindrical
+
+    ### Flesh
+
+    - **Color & Changes:** Corky, pale buff; no dark bands
+    - **Odor:** Mild, resinous
+    - **Taste:** Very bitter
+
+    ### Spore Print
+
+    - **Color:** Brown
+
+  </TabItem>
+
+  <TabItem label="Microscopic" icon="microscope">
+    - **Spore Dimensions:** 8 – 12 × 5 – 9 µm
+    - **Spore Shape:** Ellipsoid, truncate ends
+    - **Ornamentation:** Double-walled, smooth outer wall
+    - **Basidia / Cystidia:** Trimitic hyphal system with clamp connections; cystidia absent
+  </TabItem>
+</Tabs>
+{/* prettier-ignore-end */}
+
+## 4. Chemical Profile
+
+- **Toxic Compounds:** None known
+- **Medicinal Compounds:** β-glucans (immunomodulators), ganoderic acids (triterpenoids), LZ-8 protein, ergosterol, adenosine
+- **Nutritional Snapshot:** Minimal calories; trace proteins, sterols, minerals
+- **Secondary Metabolites:** >400 compounds (polysaccharides, triterpenes, phenols, sterols)
+- **Chemical Tests:** KOH – no color change; FeSO₄ – no reaction
+
+## 5. DNA & Genetics
+
+| Marker     | Accession                   |
+| ---------- | --------------------------- |
+| ITS        | KF291741                    |
+| LSU        | JX869105                    |
+| SSU        | EU784293                    |
+| Additional | TEF1-α: MW461198, RPB1/RPB2 |
+
+- **Genome Assembly:** ~43.3 Mb draft (16,113 genes; PNAS 2012)
+- **Voucher Specimen:** Curtis Herbarium (lectotype uncertain)
+
+## 6. Ecology & Habitat
+
+- **Habitat:** Dead or dying hardwood in warm temperate forests
+- **Substrate:** Deciduous stumps, buried roots; occasional weak parasite on live trees
+- **Symbiosis / Trophic Type:** White-rot saprotroph (lignin decomposer)
+- **Ecological Role:** Nutrient recycling, wood decay, habitat for succession
+- **Distribution:** Europe (native), Asia & N. America (cultivated/introduced)
+- **Altitude Range:** Sea level – 1500 m
+- **Population Status:** Locally uncommon in wild; abundant in cultivation
+
+## 7. Environmental Tolerances
+
+- **Temperature Range:** 15 – 30 °C (optimum 25–30 °C)
+- **Moisture Needs:** High humidity (>80 % RH)
+- **pH Range:** 4.0 – 7.0 (optimum ~5.0)
+- **Light:** Diffuse light needed for cap formation (dark yields “antler” forms)
+- **USDA Zones:** 6 – 10
+
+## 8. Culinary Information
+
+<Aside type="tip" title="Culinary Overview">
+  Not a food mushroom—used exclusively for medicinal extracts and teas.
+</Aside>
+
+- **Common Uses:** Decoction (tea), tincture, extract, powdered capsules
+- **Preparation Requirements:** Simmer dried slices for 2+ hours; dual solvent extracts (water + ethanol) for full compound profile
+- **Flavor & Texture:** Woody, fibrous, intensely bitter
+- **Nutritional Value:** Negligible as food; valued for bioactives instead
+- **Cautions:** Do not eat raw; use as directed
+
+## 9. Toxicity & Safety
+
+<Card title="Toxicity Details" icon="shield">
+  **Status:** Non-toxic (medicinal use)
+  <br />
+  **Toxins:** None identified
+  <br />
+  **Symptoms:** Rare dryness, rash, GI upset, bleeding risk (anticoagulants)
+  <br />
+  **Treatment:** Discontinue; supportive care if needed
+</Card>
+
+## 10. Cultural & Historical Significance
+
+- **Common Names:** Reishi (JP), Lingzhi (CN), Mannentake (JP), Bullocho (KR)
+- **Folklore & Mythology:** Symbol of immortality & divine blessing; grows in “abodes of immortals”; motif in Chinese art & Taoist lore
+- **Traditional Uses:** TCM Qi-tonic, Shen-calming, longevity herb; Kampo tonic; Korean elixir of youth
+- **Historic References:** _Shen Nong Ben Cao Jing_ (1st c. AD); _Nihon Shoki_ (720 AD); Ming/Qing dynasty art & _Bencao Gangmu_
+
+## 11. Dispersal & Restoration
+
+- **Spore Dispersal:** Wind-blown basidiospores (~billions/day) from pore surface
+- **Reproduction Mode:** Sexual spores; trimitic dikaryotic mycelium
+- **Cultivation Difficulty:** Moderate—requires wood substrate, humidity, moderate temperatures
+- **Restoration Protocols:** Inoculate logs with spawn; retain deadwood in forests; encourage natural spore seeding
+- **Conservation Notes:** Supports nutrient cycling; habitat retention (deadwood) benefits ecosystem
+
+## 12. Similar Species & Misidentifications
+
+| Look-alike                            | Key Differences                                            | Risk                 |
+| ------------------------------------- | ---------------------------------------------------------- | -------------------- |
+| _Ganoderma lingzhi_ (Asian “Lingzhi”) | Melanoid bands in flesh; predominantly Asian hardwood host | Medium (labeling)    |
+| _Ganoderma tsugae_ (Hemlock reishi)   | Grows on conifers; whiter, spongier context                | Low (substrate clue) |
+
+## 13. Conservation Status
+
+- **IUCN:** Not Evaluated
+- **Regional Status:** Uncommon in wild; listed as rare in some European Red Lists (Belarus, Finland)
+- **Threats:** Habitat loss (removal of dead wood), forestry practices
+- **Population Trend:** Stable in cultivation; declining in unmanaged wild
+- **Actions:** Protect deadwood in forests; fungal biodiversity programs
+
+## 14. Field Identification Rubric
+
+<Steps>
+  1. Verify growth on decaying **hardwood** (oak, maple)—exclude conifer hosts.
+  2. Inspect cap: **shiny** reddish-brown with white margin, 5–15 cm,
+  **varnished** surface. 3. Check pores: **white** surface, ~4–5 pores/mm;
+  collect **brown spore print** overnight. 4. Confirm **woody corky flesh**
+  without dark bands; note presence of lateral stem.
+</Steps>
+
+<Aside type="note" title="Diagnostic Summary">
+  Shiny red-brown varnished cap, white decurrent pores, brown spore print on
+  hardwood substrate = **Reishi (Ganoderma lucidum sensu lato)**.
+</Aside>
+
+## 15. References
+
+- Moncalvo et al. (2000). Molecular phylogeny of Ganoderma complex. _Mycological Research._
+- Xu et al. (2012). Genome of Ganoderma lucidum. _PNAS._
+- Wachtel-Galor & Benzie (2011). _Herbal Medicine: Biomolecular and Clinical Aspects._
+- Loyd et al. (2018). North American laccate Ganoderma revision. _Mycologia._
+- Jian et al. (2015). DNA barcoding of reishi products. _Phytochemistry._
+
+<LinkButton href="#top" variant="minimal" icon="arrow-up" iconPlacement="start">
+  Back to top
+</LinkButton>

--- a/src/content/docs/Guides/cantharellus-cibarius.mdx
+++ b/src/content/docs/Guides/cantharellus-cibarius.mdx
@@ -1,0 +1,224 @@
+---
+title: "Golden Chanterelle (Cantharellus cibarius)"
+description: "Comprehensive species profile for the golden chanterelle."
+---
+
+import {
+  Card,
+  CardGrid,
+  Badge,
+  Aside,
+  Steps,
+  Tabs,
+  TabItem,
+  Icon,
+  LinkButton,
+} from "@astrojs/starlight/components";
+
+# _Cantharellus cibarius_
+
+{/* prettier-ignore-start */}
+
+<CardGrid stagger>
+  <Card title="Quick Facts" icon="sparkles">
+    - <Badge text="Edible" variant="success" />- **Cap**: Convex→funnel,
+    3–10 cm, golden‑yellow - **Ridges**: Decurrent, thick, same color as cap -
+    **Spore Print**: Creamy‑white
+  </Card>
+  <Card title="Habitat Snapshot" icon="map">
+    - **Substrate**: Acidic soils in mossy forests - **Habitat**: Coniferous &
+    mixed woodlands - **Range**: Europe, N. America, parts of Asia - **Season**:
+    Jun – Oct (after rains)
+  </Card>
+</CardGrid>
+{/* prettier-ignore-end */}
+
+<Aside type="caution" title="Safety Note">
+  Easily confused with the poisonous **Jack‑o’‑Lantern** (*Omphalotus olearius*)
+  and the *False Chanterelle* (*Hygrophoropsis aurantiaca*). Confirm forked,
+  blunt ridges (not true gills) and white spore print.
+</Aside>
+
+## 1. Scientific Taxonomy
+
+| Rank              | Name                            |
+| ----------------- | ------------------------------- |
+| Kingdom           | Fungi                           |
+| Division / Phylum | Basidiomycota                   |
+| Class             | Agaricomycetes                  |
+| Order             | Cantharellales                  |
+| Family            | Cantharellaceae                 |
+| Genus             | _Cantharellus_                  |
+| Species           | _cibarius_                      |
+| Authority         | Fr. (1821)                      |
+| Synonym           | _Agaricus cibarius_ (Fr., 1821) |
+
+## 2. Discovery & Naming
+
+- **Discoverer / Describer:** Elias Magnus Fries
+- **Year Described:** 1821
+- **Type Locality:** Öland, Sweden
+- **Type Specimen ID:** UPS:Fungi:9967 (Uppsala University Herbarium)
+- **Etymology:** _cibarius_ ― Latin for “food” or “edible.”
+- **Historical Notes:** Celebrated in European cuisine since antiquity; Fries originally placed it in _Agaricus_.
+
+## 3. Morphological Characteristics
+
+{/* prettier-ignore-start */}
+
+<Tabs syncKey="morphology">
+  <TabItem label="Macroscopic" icon="eye">
+
+    ### Cap
+
+    - **Shape:** Convex in youth, becoming funnel‑shaped with wavy margin
+    - **Size:** 3 – 10 cm diameter (rarely to 15 cm)
+    - **Color:** Deep golden‑yellow to egg‑yolk orange
+    - **Surface:** Smooth, matte to slightly plush; dry even when wet
+
+    ### Ridges (False Gills)
+
+    - **Type:** Thick, forked ridges rather than true gills
+    - **Attachment:** Decurrent – running down the stem
+    - **Color:** Paler yellow to same as cap
+
+    ### Stem
+
+    - **Present:** Yes
+    - **Dimensions:** 3 – 8 cm × 1 – 2 cm, tapering downwards
+    - **Characteristics:** Solid, smooth, same color or slightly paler than cap
+
+    ### Flesh
+
+    - **Color & Changes:** Whitish to light yellow; does not bruise
+    - **Odor:** Distinct apricot or fruity
+    - **Taste:** Mild, peppery when raw; pleasant when cooked
+
+    ### Spore Print
+
+    - **Color:** White to pale cream (4A2–4B3, Kornerup & Wanscher)
+
+  </TabItem>
+
+  <TabItem label="Microscopic" icon="microscope">
+    - **Spore Dimensions:** 7 – 10 × 5 – 6 µm
+    - **Spore Shape:** Ellipsoid, smooth, thin‑walled
+    - **Ornamentation:** Smooth, non‑amyloid
+    - **Basidia / Cystidia:** Basidia 4-spored; cystidia absent
+  </TabItem>
+</Tabs>
+{/* prettier-ignore-end */}
+
+## 4. Chemical Profile
+
+- **Toxic Compounds:** None known
+- **Medicinal Compounds:** Beta‑glucans, carotenoids (e.g., canthaxanthin) showing antioxidant properties
+- **Nutritional Snapshot:** ≈31 kcal/100 g fresh; 1.5 g protein, rich in vitamin D2, potassium, and B‑vitamins
+- **Secondary Metabolites:** Pigments responsible for yellow coloration; sesquiterpenes
+- **Chemical Tests:** KOH on cap → no color change; iron salts → negative
+
+## 5. DNA & Genetics
+
+| Marker | Accession |
+| ------ | --------- |
+| ITS    | KF291741  |
+| LSU    | JX869105  |
+| SSU    | EU784293  |
+| TEF1‑α | MW461198  |
+
+- **Genome Assembly:** Draft assemblies in progress
+- **Voucher Specimen:** UPS:Fungi:9967 (holotype)
+
+## 6. Ecology & Habitat
+
+- **Habitat:** Moist, moss‑covered forest floor, often along paths or clearings
+- **Substrate:** Soil; ectomycorrhizal with _Picea_, _Pinus_, _Betula_, _Quercus_
+- **Symbiosis / Trophic Type:** Ectomycorrhizal (mutualistic)
+- **Ecological Role:** Enhances nutrient exchange, particularly nitrogen and phosphorus, benefiting host trees
+- **Distribution:** Temperate Europe; counterparts in North America & Asia
+- **Altitude Range:** Sea level – 2000 m
+- **Population Status:** Abundant where habitat intact
+
+## 7. Environmental Tolerances
+
+- **Temperature Range:** 10 – 25 °C (fruiting peaks ~18 °C)
+- **Moisture Needs:** Requires high soil moisture following sustained rainfall
+- **pH Range:** Prefers acidic soils, pH 4 – 6
+- **Light:** Fruiting in shaded understory or dappled light
+- **USDA Zones:** 3 – 8
+
+## 8. Culinary Information
+
+<Aside type="tip" title="Culinary Overview">
+  Considered a **choice** edible across Europe and North America.
+</Aside>
+
+- **Common Uses:** Sautéed in butter, cream sauces, soups, pickled, or dried for later rehydration
+- **Preparation Requirements:** Thorough cooking enhances flavor and texture; avoid consuming raw (indigestion)
+- **Flavor & Texture:** Firm, nutty, faint apricot scent; retains structure, does not become slimy
+- **Nutritional Value:** Low calorie, good source of vitamin D2 and potassium
+- **Cautions:** Inspect for insects; ensure correct ID to avoid toxic look‑alikes
+
+## 9. Toxicity & Safety
+
+<Card title="Toxicity Details" icon="shield">
+  **Status:** Non‑toxic / Edible **Toxins:** None identified **Symptoms:** N/A
+  **Treatment:** N/A
+</Card>
+
+## 10. Cultural & Historical Significance
+
+- **Common Names:** Golden Chanterelle, Girolle (FR), Pfifferling (DE), Kantarell (SE)
+- **Folklore & Mythology:** Symbol of gold and good fortune; historically sold at high value in European markets
+- **Traditional Uses:** Featured in Scandinavian and French cuisines; dried chanterelles valued for winter stews
+- **Historic References:** Mentioned in 16th‑century herbal texts; prized at the court of Louis XIV
+
+## 11. Dispersal & Restoration
+
+- **Spore Dispersal:** Wind‑borne basidiospores released from ridges
+- **Reproduction Mode:** Sexual spores; mycelium can persist for decades
+- **Cultivation Difficulty:** Difficult – requires compatible host trees and forest soil microbiome
+- **Restoration Protocols:** Inoculate spruce/birch seedlings with spore slurry or mycelial plugs; maintain natural leaf litter; avoid soil compaction
+- **Conservation Notes:** Sensitive to clear‑cutting; promote mixed‑age forests for long‑term sustainability
+
+## 12. Similar Species & Misidentifications
+
+| Look‑alike                                      | Key Differences                                                          | Risk                    |
+| ----------------------------------------------- | ------------------------------------------------------------------------ | ----------------------- |
+| _Omphalotus olearius_ (Jack‑o’‑Lantern)         | True sharp gills, orange spore print, bioluminescent, grows on wood      | Deadly                  |
+| _Hygrophoropsis aurantiaca_ (False Chanterelle) | Thin forked gills but more regular, deeper orange cap, hollow cap center | Gastro‑intestinal upset |
+
+## 13. Conservation Status
+
+- **IUCN:** Least Concern (LC)
+- **Regional Status:** Protected from commercial harvest in parts of Scandinavia
+- **Threats:** Habitat loss via clear‑cutting and soil disturbance
+- **Population Trend:** Stable overall
+- **Actions:** Encourage sustainable foraging; maintain forest integrity
+
+## 14. Field Identification Rubric
+
+<Steps>
+  1. **Habitat Check:** Acidic, mossy conifer forest after midsummer rains. 2.
+  **Cap Examination:** Golden, funnel‑shaped cap with wavy edge; flesh white. 3.
+  **Ridges vs. Gills:** Blunt, forked ridges decurrent on stem (not thin true
+  gills). 4. **Spore Print:** Collect overnight – must be white/cream. 5.
+  **Look‑alike Cross‑check:** Confirm absence of true gills and wood‑growing
+  habit.
+</Steps>
+
+<Aside type="note" title="Diagnostic Summary">
+  Golden cap, blunt decurrent ridges, fruity apricot scent, white spore print,
+  and growth on forest floor with conifers = **Golden Chanterelle**.
+</Aside>
+
+## 15. References
+
+- Fries, E. M. (1821). _Systema Mycologicum_.
+- Arora, D. (1986). _Mushrooms Demystified_.
+- IUCN Red List entry for _Cantharellus cibarius_ (2020).
+- Læssøe, T., & Petersen, J. H. (2019). _Fungi of Temperate Europe_.
+
+<LinkButton href="#top" variant="minimal" icon="arrow-up" iconPlacement="start">
+  Back to top
+</LinkButton>

--- a/src/content/docs/foraging/foraging-faq.md
+++ b/src/content/docs/foraging/foraging-faq.md
@@ -1,0 +1,32 @@
+---
+title: Foraging FAQ
+description: Answers to the most common beginner questions about wild mushroom safety, identification, and handling.
+---
+
+## Are all mushrooms safe to eat?
+
+Unfortunately, no. North America alone hosts hundreds of toxic species, including several that can be fatal after only a few bites. Always confirm an identification with multiple trusted resources before you even think about cooking a wild mushroom. When in doubt, walk away or buy from a reputable grower instead.
+
+## How can I identify edible mushrooms confidently?
+
+Look at more than one feature. Cap colour and shape, pore or gill spacing, stem texture, bruising reactions, odour, habitat, and spore print colour all matter. Cross-check these traits in a current regional field guide, work with a local mycological society, and take clear photos for later comparison. If any detail conflicts, assume the specimen is unsafe.
+
+## What health benefits do edible mushrooms offer?
+
+Many culinary species provide B vitamins, selenium, copper, and antioxidant compounds while remaining low in calories. Shiitake, maitake, and other gourmet fungi have also been studied for immune-modulating polysaccharides. Treat them as a nutritious addition to a balanced diet rather than a cure-all.
+
+## Are mushrooms a good source of protein?
+
+Mushrooms contribute some protein—generally between 2–4 grams per 100 grams fresh weight—but not nearly as much as legumes or meat. Use them to complement, not replace, the primary protein in a meal.
+
+## How should I store fresh mushrooms?
+
+Keep them cool and dry. A paper bag or other breathable container in the refrigerator prevents condensation and slows spoilage. Skip sealed plastic; trapped moisture quickly turns firm mushrooms into a slimy mess. Most wild harvests taste best within a few days.
+
+## Can mushrooms be poisonous?
+
+Yes. Poisonings range from gastric upset to liver failure depending on the species. Symptoms may be delayed by hours, so seek medical care immediately if someone eats a suspect mushroom. Bring a specimen or clear photos to help toxicologists identify the culprit.
+
+## What are the most dangerous mushrooms, and how do I avoid them?
+
+Death caps (_Amanita phalloides_), destroying angels (_Amanita bisporigera_ and relatives), and several other _Amanita_ species cause the majority of fatal cases. Learn their hallmark traits—white gills, a skirt-like ring, and a cup-shaped volva at the base of the stem—and never harvest a mushroom without exposing the entire base. Partner with an experienced identifier until you can reliably recognize local hazards on your own.


### PR DESCRIPTION
## Summary
- add the legacy mushroom foraging FAQ content to the docs so the section has actionable safety guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cba02825408323984f418f910c21e7