### PR TITLE
Add legacy community pages to Starlight

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,10 +1,13 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z } from "astro:content";
 
 const docs = defineCollection({
-  type: 'content',
+  type: "content",
   schema: z.object({
     title: z.string().optional(),
     description: z.string().optional(),
+    author: z.string().optional(),
+    pubDate: z.coerce.date().optional(),
+    tags: z.array(z.string()).optional(),
   }),
 });
 

--- a/src/content/docs/blog/authors/asmith.mdx
+++ b/src/content/docs/blog/authors/asmith.mdx
@@ -1,0 +1,16 @@
+---
+title: Alex Smith
+description: Cultivator and educator sharing practical techniques for mushroom growers.
+tags:
+  - community
+---
+
+![Alex Smith avatar](https://via.placeholder.com/150 "Alex Smith")
+
+Cultivator and educator sharing practical techniques for mushroom growers.
+
+## Recent Posts
+
+- **October 15, 2023** — [Cultivation Basics for Beginners](/blog/cultivation-basics)
+
+[Back to all authors](/blog/authors)

--- a/src/content/docs/blog/authors/index.mdx
+++ b/src/content/docs/blog/authors/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Our Authors
+description: Meet the writers and cultivators contributing to MycoSci.
+tags:
+  - community
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+## Contributors
+
+<CardGrid>
+  <Card title="Jane Doe" href="/blog/authors/jdoe" icon="person">
+    Science writer and mycology enthusiast who loves exploring the hidden world
+    of fungi.
+  </Card>
+  <Card title="Alex Smith" href="/blog/authors/asmith" icon="person">
+    Cultivator and educator sharing practical techniques for mushroom growers.
+  </Card>
+</CardGrid>

--- a/src/content/docs/blog/authors/jdoe.mdx
+++ b/src/content/docs/blog/authors/jdoe.mdx
@@ -1,0 +1,17 @@
+---
+title: Jane Doe
+description: Science writer and mycology enthusiast who loves exploring the hidden world of fungi.
+tags:
+  - community
+---
+
+![Jane Doe avatar](https://via.placeholder.com/150 "Jane Doe")
+
+Science writer and mycology enthusiast who loves exploring the hidden world of fungi.
+
+## Recent Posts
+
+- **November 1, 2023** — [Fungal Frontiers: New Discoveries](/blog/fungal-frontiers)
+- **September 30, 2023** — [Edible vs. Poisonous Lookalikes](/blog/edible-vs-poisonous)
+
+[Back to all authors](/blog/authors)

--- a/src/content/docs/blog/cultivation-basics.mdx
+++ b/src/content/docs/blog/cultivation-basics.mdx
@@ -1,0 +1,22 @@
+---
+title: "Cultivation Basics for Beginners"
+description: "Starting a mushroom grow can be simple with the right approach."
+author: "Alex Smith"
+pubDate: 2023-10-15
+tags:
+  - cultivation
+---
+
+> **Published:** October 15, 2023  
+> **Author:** [Alex Smith](/blog/authors/asmith)
+
+With just a few supplies and some patience, you can cultivate gourmet mushrooms at home. We'll cover substrate preparation, inoculation, and fruiting conditions.
+
+## About the Author
+
+Cultivator and educator sharing practical techniques for mushroom growers.
+
+## More Posts
+
+- [Fungal Frontiers: New Discoveries](/blog/fungal-frontiers)
+- [Edible vs. Poisonous Lookalikes](/blog/edible-vs-poisonous)

--- a/src/content/docs/blog/edible-vs-poisonous.mdx
+++ b/src/content/docs/blog/edible-vs-poisonous.mdx
@@ -1,0 +1,23 @@
+---
+title: "Edible vs. Poisonous Lookalikes"
+description: "Learn to tell delicious mushrooms from dangerous imposters."
+author: "Jane Doe"
+pubDate: 2023-09-30
+tags:
+  - safety
+  - foraging
+---
+
+> **Published:** September 30, 2023  
+> **Author:** [Jane Doe](/blog/authors/jdoe)
+
+Field identification is a vital skill for foragers. We'll compare common edible species with their toxic counterparts and share tips to stay safe.
+
+## About the Author
+
+Science writer and mycology enthusiast who loves exploring the hidden world of fungi.
+
+## More Posts
+
+- [Fungal Frontiers: New Discoveries](/blog/fungal-frontiers)
+- [Cultivation Basics for Beginners](/blog/cultivation-basics)

--- a/src/content/docs/blog/fungal-frontiers.mdx
+++ b/src/content/docs/blog/fungal-frontiers.mdx
@@ -1,0 +1,22 @@
+---
+title: "Fungal Frontiers: New Discoveries"
+description: "Recent research is uncovering amazing fungal secrets."
+author: "Jane Doe"
+pubDate: 2023-11-01
+tags:
+  - research
+---
+
+> **Published:** November 1, 2023  
+> **Author:** [Jane Doe](/blog/authors/jdoe)
+
+The world of mycology is expanding with new species and novel applications discovered each year. From bioremediation to sustainable materials, fungi are proving to be indispensable allies.
+
+## About the Author
+
+Science writer and mycology enthusiast who loves exploring the hidden world of fungi.
+
+## More Posts
+
+- [Cultivation Basics for Beginners](/blog/cultivation-basics)
+- [Edible vs. Poisonous Lookalikes](/blog/edible-vs-poisonous)

--- a/src/content/docs/blog/index.mdx
+++ b/src/content/docs/blog/index.mdx
@@ -1,0 +1,48 @@
+---
+title: MycoSci Blog
+description: Insights and updates from the world of fungi.
+tags:
+  - community
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+> **Mission Briefings** keep you aligned with the latest discoveries, cultivation wins, and safety notes from the field.
+
+## Latest Posts
+
+<CardGrid>
+  <Card
+    title="Fungal Frontiers: New Discoveries"
+    href="/blog/fungal-frontiers"
+    icon="sparkles"
+  >
+    Recent research is uncovering amazing fungal secrets.
+  </Card>
+  <Card
+    title="Cultivation Basics for Beginners"
+    href="/blog/cultivation-basics"
+    icon="seedling"
+  >
+    Starting a mushroom grow can be simple with the right approach.
+  </Card>
+  <Card
+    title="Edible vs. Poisonous Lookalikes"
+    href="/blog/edible-vs-poisonous"
+    icon="shield"
+  >
+    Learn to tell delicious mushrooms from dangerous imposters.
+  </Card>
+</CardGrid>
+
+## Meet Our Contributors
+
+<CardGrid>
+  <Card title="Jane Doe" href="/blog/authors/jdoe" icon="person">
+    Science writer and mycology enthusiast who loves exploring the hidden world
+    of fungi.
+  </Card>
+  <Card title="Alex Smith" href="/blog/authors/asmith" icon="person">
+    Cultivator and educator sharing practical techniques for mushroom growers.
+  </Card>
+</CardGrid>

--- a/src/content/docs/gallery/index.mdx
+++ b/src/content/docs/gallery/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Mushroom Gallery
+description: A visual tour of our fungal friends.
+tags:
+  - community
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+Explore a rotating selection of favorite finds from the community. High-resolution uploads will return as contributors submit new shots.
+
+<CardGrid>
+  <Card title="Amazing mushroom #1">
+    <img src="/houston.webp" alt="Mushroom snapshot one" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #2">
+    <img src="/houston.webp" alt="Mushroom snapshot two" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #3">
+    <img src="/houston.webp" alt="Mushroom snapshot three" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #4">
+    <img src="/houston.webp" alt="Mushroom snapshot four" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #5">
+    <img src="/houston.webp" alt="Mushroom snapshot five" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #6">
+    <img src="/houston.webp" alt="Mushroom snapshot six" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #7">
+    <img src="/houston.webp" alt="Mushroom snapshot seven" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #8">
+    <img src="/houston.webp" alt="Mushroom snapshot eight" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #9">
+    <img src="/houston.webp" alt="Mushroom snapshot nine" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #10">
+    <img src="/houston.webp" alt="Mushroom snapshot ten" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #11">
+    <img src="/houston.webp" alt="Mushroom snapshot eleven" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #12">
+    <img src="/houston.webp" alt="Mushroom snapshot twelve" loading="lazy" />
+  </Card>
+</CardGrid>

--- a/src/content/docs/mycogram/index.mdx
+++ b/src/content/docs/mycogram/index.mdx
@@ -1,0 +1,64 @@
+---
+title: MycoGram
+description: Share and explore mushroom photos from around the world.
+tags:
+  - community
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+MycoGram is our community photo stream. Uploads will return soon, but the highlights below keep the feed alive while the new platform spins up.
+
+## Photo Stream
+
+<CardGrid>
+  <Card title="Amazing mushroom #1">
+    <img src="/houston.webp" alt="Mushroom snapshot one" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #2">
+    <img src="/houston.webp" alt="Mushroom snapshot two" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #3">
+    <img src="/houston.webp" alt="Mushroom snapshot three" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #4">
+    <img src="/houston.webp" alt="Mushroom snapshot four" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #5">
+    <img src="/houston.webp" alt="Mushroom snapshot five" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #6">
+    <img src="/houston.webp" alt="Mushroom snapshot six" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #7">
+    <img src="/houston.webp" alt="Mushroom snapshot seven" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #8">
+    <img src="/houston.webp" alt="Mushroom snapshot eight" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #9">
+    <img src="/houston.webp" alt="Mushroom snapshot nine" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #10">
+    <img src="/houston.webp" alt="Mushroom snapshot ten" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #11">
+    <img src="/houston.webp" alt="Mushroom snapshot eleven" loading="lazy" />
+  </Card>
+  <Card title="Amazing mushroom #12">
+    <img src="/houston.webp" alt="Mushroom snapshot twelve" loading="lazy" />
+  </Card>
+</CardGrid>
+
+## Top Contributors
+
+| Rank | Username | Points | Favorite Species      |
+| ---- | -------- | ------ | --------------------- |
+| 1    | asmith   | 120    | _Pleurotus ostreatus_ |
+| 2    | jdoe     | 90     | _Amanita muscaria_    |
+| 3    | guest    | 45     | _Amanita muscaria_    |
+
+## Forum Highlights
+
+- **Best methods for oyster cultivation?** — 4 replies, focused on _Pleurotus ostreatus_.
+- **Share your favorite mushroom photos** — 8 replies featuring _Amanita muscaria_.

--- a/src/content/docs/resources/index.mdx
+++ b/src/content/docs/resources/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Resources
+description: Videos, podcasts, webinars, and research materials for mycology.
+tags:
+  - community
+---
+
+Welcome to the resources depot. We're curating videos, podcasts, webinars, and research materials for the whole community.
+
+## What's Coming Next
+
+- A refreshed archive of open-access research papers.
+- Playlists of our favorite cultivation and identification tutorials.
+- Recorded talks and webinars from MycoSci collaborators.
+
+Have a link we should feature? [Open an issue on GitHub](https://github.com/MycoSci/mycosci.github.io/issues) with the details and we'll add it to the queue.

--- a/starlight.config.mjs
+++ b/starlight.config.mjs
@@ -62,5 +62,14 @@ export default {
       label: "Legacy Reference",
       autogenerate: { directory: "Reference" },
     },
+    {
+      label: "Community",
+      items: [
+        { label: "Blog", autogenerate: { directory: "blog" } },
+        { label: "Gallery", link: "/gallery/" },
+        { label: "MycoGram", link: "/mycogram/" },
+        { label: "Resources", link: "/resources/" },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- add Starlight blog index, individual posts, and author pages to preserve legacy articles
- recreate gallery, MycoGram, and resources landing pages inside the docs collection
- extend the content schema and sidebar to surface the new community section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc2e9d047c832387df092207825d7d