### PR TITLE
Enable Starlight doc build output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,10 @@
       "name": "far-field",
       "version": "0.0.1",
       "dependencies": {
+        "@astrojs/mdx": "^4.2.5",
+        "@astrojs/starlight": "^0.32.3",
         "astro": "^5.6.1",
-        "sharp": "^0.32.5",
-        "@astrojs/mdx": "^4.2.5"
+        "sharp": "^0.32.5"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -102,6 +103,229 @@
         "sitemap": "^8.0.0",
         "stream-replace-string": "^2.0.0",
         "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@astrojs/starlight": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.32.6.tgz",
+      "integrity": "sha512-ASWGwNzq+0TmJ+GJFFxFFxx6Yra7BqIIMQbvOy/cweTHjqejB6mcaEWtS3Mag12LM7tXCES7v/fzmdPgjz8Yxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/mdx": "^4.0.5",
+        "@astrojs/sitemap": "^3.2.1",
+        "@pagefind/default-ui": "^1.3.0",
+        "@types/hast": "^3.0.4",
+        "@types/js-yaml": "^4.0.9",
+        "@types/mdast": "^4.0.4",
+        "astro-expressive-code": "^0.40.0",
+        "bcp-47": "^2.1.0",
+        "hast-util-from-html": "^2.0.1",
+        "hast-util-select": "^6.0.2",
+        "hast-util-to-string": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "i18next": "^23.11.5",
+        "js-yaml": "^4.1.0",
+        "klona": "^2.0.6",
+        "mdast-util-directive": "^3.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "mdast-util-to-string": "^4.0.0",
+        "pagefind": "^1.3.0",
+        "rehype": "^13.0.1",
+        "rehype-format": "^5.0.0",
+        "remark-directive": "^3.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.2"
+      },
+      "peerDependencies": {
+        "astro": "^5.1.5"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@expressive-code/core": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.40.2.tgz",
+      "integrity": "sha512-gXY3v7jbgz6nWKvRpoDxK4AHUPkZRuJsM79vHX/5uhV9/qX6Qnctp/U/dMHog/LCVXcuOps+5nRmf1uxQVPb3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ctrl/tinycolor": "^4.0.4",
+        "hast-util-select": "^6.0.2",
+        "hast-util-to-html": "^9.0.1",
+        "hast-util-to-text": "^4.0.1",
+        "hastscript": "^9.0.0",
+        "postcss": "^8.4.38",
+        "postcss-nested": "^6.0.1",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@expressive-code/plugin-frames": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.40.2.tgz",
+      "integrity": "sha512-aLw5IlDlZWb10Jo/TTDCVsmJhKfZ7FJI83Zo9VDrV0OBlmHAg7klZqw68VDz7FlftIBVAmMby53/MNXPnMjTSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.40.2"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@expressive-code/plugin-shiki": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.40.2.tgz",
+      "integrity": "sha512-t2HMR5BO6GdDW1c1ISBTk66xO503e/Z8ecZdNcr6E4NpUfvY+MRje+LtrcvbBqMwWBBO8RpVKcam/Uy+1GxwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.40.2",
+        "shiki": "^1.26.1"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@expressive-code/plugin-text-markers": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.40.2.tgz",
+      "integrity": "sha512-/XoLjD67K9nfM4TgDlXAExzMJp6ewFKxNpfUw4F7q5Ecy+IU3/9zQQG/O70Zy+RxYTwKGw2MA9kd7yelsxnSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.40.2"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@shikijs/core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
+      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@shikijs/engine-javascript": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
+      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "oniguruma-to-es": "^2.2.0"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@shikijs/engine-oniguruma": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
+      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@shikijs/langs": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
+      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@shikijs/themes": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
+      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/@shikijs/types": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
+      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/astro-expressive-code": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.40.2.tgz",
+      "integrity": "sha512-yJMQId0yXSAbW9I6yqvJ3FcjKzJ8zRL7elbJbllkv1ZJPlsI0NI83Pxn1YL1IapEM347EvOOkSW2GL+2+NO61w==",
+      "license": "MIT",
+      "dependencies": {
+        "rehype-expressive-code": "^0.40.2"
+      },
+      "peerDependencies": {
+        "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/expressive-code": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.40.2.tgz",
+      "integrity": "sha512-1zIda2rB0qiDZACawzw2rbdBQiWHBT56uBctS+ezFe5XMAaFaHLnnSYND/Kd+dVzO9HfCXRDpzH3d+3fvOWRcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expressive-code/core": "^0.40.2",
+        "@expressive-code/plugin-frames": "^0.40.2",
+        "@expressive-code/plugin-shiki": "^0.40.2",
+        "@expressive-code/plugin-text-markers": "^0.40.2"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/oniguruma-to-es": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
+      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^5.1.1",
+        "regex-recursion": "^5.1.1"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/regex": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
+      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/regex-recursion": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
+      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
+      "license": "MIT",
+      "dependencies": {
+        "regex": "^5.1.1",
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/rehype-expressive-code": {
+      "version": "0.40.2",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.40.2.tgz",
+      "integrity": "sha512-+kn+AMGCrGzvtH8Q5lC6Y5lnmTV/r33fdmi5QU/IH1KPHKobKr5UnLwJuqHv5jBTSN/0v2wLDS7RTM73FVzqmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expressive-code": "^0.40.2"
+      }
+    },
+    "node_modules/@astrojs/starlight/node_modules/shiki": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
+      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "1.29.2",
+        "@shikijs/engine-javascript": "1.29.2",
+        "@shikijs/engine-oniguruma": "1.29.2",
+        "@shikijs/langs": "1.29.2",
+        "@shikijs/themes": "1.29.2",
+        "@shikijs/types": "1.29.2",
+        "@shikijs/vscode-textmate": "^10.0.1",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -608,51 +832,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@expressive-code/core": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.41.2.tgz",
-      "integrity": "sha512-AJW5Tp9czbLqKMzwudL9Rv4js9afXBxkSGLmCNPq1iRgAYcx9NkTPJiSNCesjKRWoVC328AdSu6fqrD22zDgDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@ctrl/tinycolor": "^4.0.4",
-        "hast-util-select": "^6.0.2",
-        "hast-util-to-html": "^9.0.1",
-        "hast-util-to-text": "^4.0.1",
-        "hastscript": "^9.0.0",
-        "postcss": "^8.4.38",
-        "postcss-nested": "^6.0.1",
-        "unist-util-visit": "^5.0.0",
-        "unist-util-visit-parents": "^6.0.1"
-      }
-    },
-    "node_modules/@expressive-code/plugin-frames": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.41.2.tgz",
-      "integrity": "sha512-pfy0hkJI4nbaONjmksFDcuHmIuyPTFmi1JpABe4q2ajskiJtfBf+WDAL2pg595R9JNoPrrH5+aT9lbkx2noicw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.2"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.41.2.tgz",
-      "integrity": "sha512-xD4zwqAkDccXqye+235BH5bN038jYiSMLfUrCOmMlzxPDGWdxJDk5z4uUB/aLfivEF2tXyO2zyaarL3Oqht0fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.2",
-        "shiki": "^3.2.2"
-      }
-    },
-    "node_modules/@expressive-code/plugin-text-markers": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.41.2.tgz",
-      "integrity": "sha512-JFWBz2qYxxJOJkkWf96LpeolbnOqJY95TvwYc0hXIHf9oSWV0h0SY268w/5N3EtQaD9KktzDE+VIVwb9jdb3nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.2"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
@@ -1840,18 +2019,6 @@
         "sharp": "^0.33.3"
       }
     },
-    "node_modules/astro-expressive-code": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.41.2.tgz",
-      "integrity": "sha512-HN0jWTnhr7mIV/2e6uu4PPRNNo/k4UEgTLZqbp3MrHU+caCARveG2yZxaZVBmxyiVdYqW5Pd3u3n2zjnshixbw==",
-      "license": "MIT",
-      "dependencies": {
-        "rehype-expressive-code": "^0.41.2"
-      },
-      "peerDependencies": {
-        "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
-      }
-    },
     "node_modules/astro/node_modules/sharp": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -2577,6 +2744,12 @@
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -2792,18 +2965,6 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/expressive-code": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.41.2.tgz",
-      "integrity": "sha512-aLZiZaqorRtNExtGpUjK9zFH9aTpWeoTXMyLo4b4IcuXfPqtLPPxhRm/QlPb8QqIcMMXnSiGRHSFpQfX0m7HJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.2",
-        "@expressive-code/plugin-frames": "^0.41.2",
-        "@expressive-code/plugin-shiki": "^0.41.2",
-        "@expressive-code/plugin-text-markers": "^0.41.2"
       }
     },
     "node_modules/extend": {
@@ -5357,15 +5518,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-expressive-code": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.41.2.tgz",
-      "integrity": "sha512-vHYfWO9WxAw6kHHctddOt+P4266BtyT1mrOIuxJD+1ELuvuJAa5uBIhYt0OVMyOhlvf57hzWOXJkHnMhpaHyxw==",
-      "license": "MIT",
-      "dependencies": {
-        "expressive-code": "^0.41.2"
       }
     },
     "node_modules/rehype-format": {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,13 +1,14 @@
 import { defineCollection, z } from "astro:content";
+import { docsSchema } from "@astrojs/starlight/schema";
 
 const docs = defineCollection({
   type: "content",
-  schema: z.object({
-    title: z.string().optional(),
-    description: z.string().optional(),
-    author: z.string().optional(),
-    pubDate: z.coerce.date().optional(),
-    tags: z.array(z.string()).optional(),
+  schema: docsSchema({
+    extend: z.object({
+      author: z.string().optional(),
+      pubDate: z.coerce.date().optional(),
+      tags: z.array(z.string()).optional(),
+    }),
   }),
 });
 

--- a/src/content/docs/Guides/Amanita-muscaria.mdx
+++ b/src/content/docs/Guides/Amanita-muscaria.mdx
@@ -165,16 +165,18 @@ import {
 ### Responsible Observation
 
 <Steps>
-  <li>
-    Photograph specimens in-situ to document host tree, soil type, and
-    associated species.
-  </li>
-  <li>
-    Educate foragers about dangerous look-alikes (_Amanita pantherina_, _Amanita
-    rubescens_).
-  </li>
-  <li>
-    Leave mushrooms undisturbed so they can complete their ecological role with
-    host trees.
-  </li>
+  <ol>
+    <li>
+      Photograph specimens in-situ to document host tree, soil type, and
+      associated species.
+    </li>
+    <li>
+      Educate foragers about dangerous look-alikes (_Amanita pantherina_,
+      _Amanita rubescens_).
+    </li>
+    <li>
+      Leave mushrooms undisturbed so they can complete their ecological role
+      with host trees.
+    </li>
+  </ol>
 </Steps>

--- a/src/content/docs/Guides/Ganoderma-lucidum.mdx
+++ b/src/content/docs/Guides/Ganoderma-lucidum.mdx
@@ -211,11 +211,24 @@ Historically, _G. lucidum_ has a long record of use in East Asia, being revered 
 ## 14. Field Identification Rubric
 
 <Steps>
-  1. Verify growth on decaying **hardwood** (oak, maple)—exclude conifer hosts.
-  2. Inspect cap: **shiny** reddish-brown with white margin, 5–15 cm,
-  **varnished** surface. 3. Check pores: **white** surface, ~4–5 pores/mm;
-  collect **brown spore print** overnight. 4. Confirm **woody corky flesh**
-  without dark bands; note presence of lateral stem.
+  <ol>
+    <li>
+      Verify growth on decaying <strong>hardwood</strong> (oak, maple)—exclude
+      conifer hosts.
+    </li>
+    <li>
+      Inspect the cap for a <strong>shiny</strong> reddish-brown varnished
+      surface with a white margin, typically 5–15 cm wide.
+    </li>
+    <li>
+      Check pores for a <strong>white</strong> surface with about 4–5 pores per
+      millimeter and collect a <strong>brown spore print</strong> overnight.
+    </li>
+    <li>
+      Confirm <strong>woody corky flesh</strong> without dark bands and look for
+      a lateral stem.
+    </li>
+  </ol>
 </Steps>
 
 <Aside type="note" title="Diagnostic Summary">

--- a/src/content/docs/Guides/Pleurotus-ostreatus.mdx
+++ b/src/content/docs/Guides/Pleurotus-ostreatus.mdx
@@ -161,7 +161,9 @@ import {
 </Aside>
 
 <Steps>
-  <li>Brush debris from caps; avoid soaking to maintain texture.</li>
-  <li>Sear in a hot pan with butter or oil until edges crisp.</li>
-  <li>Finish with garlic, thyme, or tamari to enhance umami depth.</li>
+  <ol>
+    <li>Brush debris from caps; avoid soaking to maintain texture.</li>
+    <li>Sear in a hot pan with butter or oil until edges crisp.</li>
+    <li>Finish with garlic, thyme, or tamari to enhance umami depth.</li>
+  </ol>
 </Steps>

--- a/src/content/docs/Guides/cantharellus-cibarius.mdx
+++ b/src/content/docs/Guides/cantharellus-cibarius.mdx
@@ -199,12 +199,28 @@ import {
 ## 14. Field Identification Rubric
 
 <Steps>
-  1. **Habitat Check:** Acidic, mossy conifer forest after midsummer rains. 2.
-  **Cap Examination:** Golden, funnel‑shaped cap with wavy edge; flesh white. 3.
-  **Ridges vs. Gills:** Blunt, forked ridges decurrent on stem (not thin true
-  gills). 4. **Spore Print:** Collect overnight – must be white/cream. 5.
-  **Look‑alike Cross‑check:** Confirm absence of true gills and wood‑growing
-  habit.
+  <ol>
+    <li>
+      <strong>Habitat Check:</strong> Search acidic, mossy conifer forests after
+      midsummer rains.
+    </li>
+    <li>
+      <strong>Cap Examination:</strong> Look for a golden, funnel-shaped cap
+      with a wavy edge and white flesh.
+    </li>
+    <li>
+      <strong>Ridges vs. Gills:</strong> Confirm blunt, forked ridges that run
+      down the stem instead of thin true gills.
+    </li>
+    <li>
+      <strong>Spore Print:</strong> Collect overnight to verify a white or cream
+      deposit.
+    </li>
+    <li>
+      <strong>Look-alike Cross-check:</strong> Ensure there are no true gills
+      and that specimens grow from soil rather than wood.
+    </li>
+  </ol>
 </Steps>
 
 <Aside type="note" title="Diagnostic Summary">

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,7 +5,8 @@ template: splash
 hero:
   tagline: Your free, community-powered field guide to the fungal kingdom.
   image:
-    file: /houston.webp # Swap for a spore-tastic image of choice
+    html: |
+      <img src="/houston.webp" alt="Downtown Houston skyline with mushrooms" loading="lazy" />
   actions:
     - text: Learn More
       link: /guides/quick-start/


### PR DESCRIPTION
## Summary
- configure the `docs` content collection with Starlight's schema and allow optional author, pubDate, and tag metadata
- update the home hero image to use inline HTML so the referenced asset resolves during content processing
- wrap each use of the `<Steps>` component in ordered lists to satisfy Starlight's requirements and unblock doc generation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68cc476f8d6483238efac74f71b20ab0